### PR TITLE
Feat/reentrant router

### DIFF
--- a/packages/veraswap-sdk/contracts/DispatcherApprovedReentrant.sol
+++ b/packages/veraswap-sdk/contracts/DispatcherApprovedReentrant.sol
@@ -36,6 +36,7 @@ abstract contract DispatcherApprovedReentrant is
 
     error InvalidCommandType(uint256 commandType);
     error BalanceTooLow();
+    error CallTargetPermit2();
 
     /// @notice Executes encoded commands along with provided inputs.
     /// @param commands A set of concatenated commands, each 1 byte in length
@@ -305,6 +306,9 @@ abstract contract DispatcherApprovedReentrant is
                 (address target, uint256 value, bytes calldata data) = CalldataCallTargetDecoder.decodeCallTarget(
                     inputs
                 );
+                // Call target cannot be PERMIT2 to avoid arbitrary token transfers
+                if (target == address(PERMIT2)) revert CallTargetPermit2();
+
                 (success, output) = payable(target).call{value: value}(data);
             } else {
                 // placeholder area for commands 0x22-0x3f

--- a/packages/veraswap-sdk/contracts/DispatcherApprovedReentrant.sol
+++ b/packages/veraswap-sdk/contracts/DispatcherApprovedReentrant.sol
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+import {V2SwapRouter} from "@uniswap/universal-router/contracts/modules/uniswap/v2/V2SwapRouter.sol";
+import {V3SwapRouter} from "@uniswap/universal-router/contracts/modules/uniswap/v3/V3SwapRouter.sol";
+import {V4SwapRouter} from "@uniswap/universal-router/contracts/modules/uniswap/v4/V4SwapRouter.sol";
+import {BytesLib} from "@uniswap/universal-router/contracts/modules/uniswap/v3/BytesLib.sol";
+import {Payments} from "@uniswap/universal-router/contracts/modules/Payments.sol";
+import {PaymentsImmutables} from "@uniswap/universal-router/contracts/modules/PaymentsImmutables.sol";
+import {V3ToV4Migrator} from "@uniswap/universal-router/contracts/modules/V3ToV4Migrator.sol";
+import {Commands} from "@uniswap/universal-router/contracts/libraries/Commands.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
+import {ActionConstants} from "@uniswap/v4-periphery/src/libraries/ActionConstants.sol";
+import {CalldataDecoder} from "@uniswap/v4-periphery/src/libraries/CalldataDecoder.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+
+import {LockWithApprovedReentrant} from "./LockWithApprovedReentrant.sol";
+import {ApprovedReentrant} from "./libraries/ApprovedReentrant.sol";
+import {CalldataCallTargetDecoder} from "./libraries/CalldataCallTargetDecoder.sol";
+import {CommandsReentrant} from "./libraries/CommandsReentrant.sol";
+
+/// @title Decodes and Executes Commands with added APPROVE_REENTRANT & CALL_TARGET commands
+/// @notice Called by the UniversalRouterApprovedReentrant contract to efficiently decode and execute a singular command
+abstract contract DispatcherApprovedReentrant is
+    Payments,
+    V2SwapRouter,
+    V3SwapRouter,
+    V4SwapRouter,
+    V3ToV4Migrator,
+    LockWithApprovedReentrant
+{
+    using BytesLib for bytes;
+    using CalldataDecoder for bytes;
+
+    error InvalidCommandType(uint256 commandType);
+    error BalanceTooLow();
+
+    /// @notice Executes encoded commands along with provided inputs.
+    /// @param commands A set of concatenated commands, each 1 byte in length
+    /// @param inputs An array of byte strings containing abi encoded inputs for each command
+    function execute(bytes calldata commands, bytes[] calldata inputs) external payable virtual;
+
+    /// @notice Public view function to be used instead of msg.sender, as the contract performs self-reentrancy and at
+    /// times msg.sender == address(this). Instead msgSender() returns the initiator of the lock
+    /// @dev overrides BaseActionsRouter.msgSender in V4Router
+    function msgSender() public view override returns (address) {
+        return _getLocker();
+    }
+
+    /// @notice Decodes and executes the given command with the given inputs
+    /// @param commandType The command type to execute
+    /// @param inputs The inputs to execute the command with
+    /// @dev 2 masks are used to enable use of a nested-if statement in execution for efficiency reasons
+    /// @return success True on success of the command, false on failure
+    /// @return output The outputs or error messages, if any, from the command
+    function dispatch(bytes1 commandType, bytes calldata inputs) internal returns (bool success, bytes memory output) {
+        uint256 command = uint8(commandType & Commands.COMMAND_TYPE_MASK);
+
+        success = true;
+
+        // 0x00 <= command < 0x21
+        if (command < Commands.EXECUTE_SUB_PLAN) {
+            // 0x00 <= command < 0x10
+            if (command < Commands.V4_SWAP) {
+                // 0x00 <= command < 0x08
+                if (command < Commands.V2_SWAP_EXACT_IN) {
+                    if (command == Commands.V3_SWAP_EXACT_IN) {
+                        // equivalent: abi.decode(inputs, (address, uint256, uint256, bytes, bool))
+                        address recipient;
+                        uint256 amountIn;
+                        uint256 amountOutMin;
+                        bool payerIsUser;
+                        assembly {
+                            recipient := calldataload(inputs.offset)
+                            amountIn := calldataload(add(inputs.offset, 0x20))
+                            amountOutMin := calldataload(add(inputs.offset, 0x40))
+                            // 0x60 offset is the path, decoded below
+                            payerIsUser := calldataload(add(inputs.offset, 0x80))
+                        }
+                        bytes calldata path = inputs.toBytes(3);
+                        address payer = payerIsUser ? msgSender() : address(this);
+                        v3SwapExactInput(map(recipient), amountIn, amountOutMin, path, payer);
+                    } else if (command == Commands.V3_SWAP_EXACT_OUT) {
+                        // equivalent: abi.decode(inputs, (address, uint256, uint256, bytes, bool))
+                        address recipient;
+                        uint256 amountOut;
+                        uint256 amountInMax;
+                        bool payerIsUser;
+                        assembly {
+                            recipient := calldataload(inputs.offset)
+                            amountOut := calldataload(add(inputs.offset, 0x20))
+                            amountInMax := calldataload(add(inputs.offset, 0x40))
+                            // 0x60 offset is the path, decoded below
+                            payerIsUser := calldataload(add(inputs.offset, 0x80))
+                        }
+                        bytes calldata path = inputs.toBytes(3);
+                        address payer = payerIsUser ? msgSender() : address(this);
+                        v3SwapExactOutput(map(recipient), amountOut, amountInMax, path, payer);
+                    } else if (command == Commands.PERMIT2_TRANSFER_FROM) {
+                        // equivalent: abi.decode(inputs, (address, address, uint160))
+                        address token;
+                        address recipient;
+                        uint160 amount;
+                        assembly {
+                            token := calldataload(inputs.offset)
+                            recipient := calldataload(add(inputs.offset, 0x20))
+                            amount := calldataload(add(inputs.offset, 0x40))
+                        }
+                        permit2TransferFrom(token, msgSender(), map(recipient), amount);
+                    } else if (command == Commands.PERMIT2_PERMIT_BATCH) {
+                        IAllowanceTransfer.PermitBatch calldata permitBatch;
+                        assembly {
+                            // this is a variable length struct, so calldataload(inputs.offset) contains the
+                            // offset from inputs.offset at which the struct begins
+                            permitBatch := add(inputs.offset, calldataload(inputs.offset))
+                        }
+                        bytes calldata data = inputs.toBytes(1);
+                        (success, output) = address(PERMIT2).call(
+                            abi.encodeWithSignature(
+                                "permit(address,((address,uint160,uint48,uint48)[],address,uint256),bytes)",
+                                msgSender(),
+                                permitBatch,
+                                data
+                            )
+                        );
+                    } else if (command == Commands.SWEEP) {
+                        // equivalent:  abi.decode(inputs, (address, address, uint256))
+                        address token;
+                        address recipient;
+                        uint160 amountMin;
+                        assembly {
+                            token := calldataload(inputs.offset)
+                            recipient := calldataload(add(inputs.offset, 0x20))
+                            amountMin := calldataload(add(inputs.offset, 0x40))
+                        }
+                        Payments.sweep(token, map(recipient), amountMin);
+                    } else if (command == Commands.TRANSFER) {
+                        // equivalent:  abi.decode(inputs, (address, address, uint256))
+                        address token;
+                        address recipient;
+                        uint256 value;
+                        assembly {
+                            token := calldataload(inputs.offset)
+                            recipient := calldataload(add(inputs.offset, 0x20))
+                            value := calldataload(add(inputs.offset, 0x40))
+                        }
+                        Payments.pay(token, map(recipient), value);
+                    } else if (command == Commands.PAY_PORTION) {
+                        // equivalent:  abi.decode(inputs, (address, address, uint256))
+                        address token;
+                        address recipient;
+                        uint256 bips;
+                        assembly {
+                            token := calldataload(inputs.offset)
+                            recipient := calldataload(add(inputs.offset, 0x20))
+                            bips := calldataload(add(inputs.offset, 0x40))
+                        }
+                        Payments.payPortion(token, map(recipient), bips);
+                    } else {
+                        // placeholder area for command 0x07
+                        revert InvalidCommandType(command);
+                    }
+                } else {
+                    // 0x08 <= command < 0x10
+                    if (command == Commands.V2_SWAP_EXACT_IN) {
+                        // equivalent: abi.decode(inputs, (address, uint256, uint256, bytes, bool))
+                        address recipient;
+                        uint256 amountIn;
+                        uint256 amountOutMin;
+                        bool payerIsUser;
+                        assembly {
+                            recipient := calldataload(inputs.offset)
+                            amountIn := calldataload(add(inputs.offset, 0x20))
+                            amountOutMin := calldataload(add(inputs.offset, 0x40))
+                            // 0x60 offset is the path, decoded below
+                            payerIsUser := calldataload(add(inputs.offset, 0x80))
+                        }
+                        address[] calldata path = inputs.toAddressArray(3);
+                        address payer = payerIsUser ? msgSender() : address(this);
+                        v2SwapExactInput(map(recipient), amountIn, amountOutMin, path, payer);
+                    } else if (command == Commands.V2_SWAP_EXACT_OUT) {
+                        // equivalent: abi.decode(inputs, (address, uint256, uint256, bytes, bool))
+                        address recipient;
+                        uint256 amountOut;
+                        uint256 amountInMax;
+                        bool payerIsUser;
+                        assembly {
+                            recipient := calldataload(inputs.offset)
+                            amountOut := calldataload(add(inputs.offset, 0x20))
+                            amountInMax := calldataload(add(inputs.offset, 0x40))
+                            // 0x60 offset is the path, decoded below
+                            payerIsUser := calldataload(add(inputs.offset, 0x80))
+                        }
+                        address[] calldata path = inputs.toAddressArray(3);
+                        address payer = payerIsUser ? msgSender() : address(this);
+                        v2SwapExactOutput(map(recipient), amountOut, amountInMax, path, payer);
+                    } else if (command == Commands.PERMIT2_PERMIT) {
+                        // equivalent: abi.decode(inputs, (IAllowanceTransfer.PermitSingle, bytes))
+                        IAllowanceTransfer.PermitSingle calldata permitSingle;
+                        assembly {
+                            permitSingle := inputs.offset
+                        }
+                        bytes calldata data = inputs.toBytes(6); // PermitSingle takes first 6 slots (0..5)
+                        (success, output) = address(PERMIT2).call(
+                            abi.encodeWithSignature(
+                                "permit(address,((address,uint160,uint48,uint48),address,uint256),bytes)",
+                                msgSender(),
+                                permitSingle,
+                                data
+                            )
+                        );
+                    } else if (command == Commands.WRAP_ETH) {
+                        // equivalent: abi.decode(inputs, (address, uint256))
+                        address recipient;
+                        uint256 amount;
+                        assembly {
+                            recipient := calldataload(inputs.offset)
+                            amount := calldataload(add(inputs.offset, 0x20))
+                        }
+                        Payments.wrapETH(map(recipient), amount);
+                    } else if (command == Commands.UNWRAP_WETH) {
+                        // equivalent: abi.decode(inputs, (address, uint256))
+                        address recipient;
+                        uint256 amountMin;
+                        assembly {
+                            recipient := calldataload(inputs.offset)
+                            amountMin := calldataload(add(inputs.offset, 0x20))
+                        }
+                        Payments.unwrapWETH9(map(recipient), amountMin);
+                    } else if (command == Commands.PERMIT2_TRANSFER_FROM_BATCH) {
+                        IAllowanceTransfer.AllowanceTransferDetails[] calldata batchDetails;
+                        (uint256 length, uint256 offset) = inputs.toLengthOffset(0);
+                        assembly {
+                            batchDetails.length := length
+                            batchDetails.offset := offset
+                        }
+                        permit2TransferFrom(batchDetails, msgSender());
+                    } else if (command == Commands.BALANCE_CHECK_ERC20) {
+                        // equivalent: abi.decode(inputs, (address, address, uint256))
+                        address owner;
+                        address token;
+                        uint256 minBalance;
+                        assembly {
+                            owner := calldataload(inputs.offset)
+                            token := calldataload(add(inputs.offset, 0x20))
+                            minBalance := calldataload(add(inputs.offset, 0x40))
+                        }
+                        success = (ERC20(token).balanceOf(owner) >= minBalance);
+                        if (!success) output = abi.encodePacked(BalanceTooLow.selector);
+                    } else {
+                        // placeholder area for command 0x0f
+                        revert InvalidCommandType(command);
+                    }
+                }
+            } else {
+                // 0x10 <= command < 0x21
+                if (command == Commands.V4_SWAP) {
+                    // pass the calldata provided to V4SwapRouter._executeActions (defined in BaseActionsRouter)
+                    _executeActions(inputs);
+                    // This contract MUST be approved to spend the token since its going to be doing the call on the position manager
+                } else if (command == Commands.V3_POSITION_MANAGER_PERMIT) {
+                    _checkV3PermitCall(inputs);
+                    (success, output) = address(V3_POSITION_MANAGER).call(inputs);
+                } else if (command == Commands.V3_POSITION_MANAGER_CALL) {
+                    _checkV3PositionManagerCall(inputs, msgSender());
+                    (success, output) = address(V3_POSITION_MANAGER).call(inputs);
+                } else if (command == Commands.V4_INITIALIZE_POOL) {
+                    PoolKey calldata poolKey;
+                    uint160 sqrtPriceX96;
+                    assembly {
+                        poolKey := inputs.offset
+                        sqrtPriceX96 := calldataload(add(inputs.offset, 0xa0))
+                    }
+                    (success, output) = address(poolManager).call(
+                        abi.encodeCall(IPoolManager.initialize, (poolKey, sqrtPriceX96))
+                    );
+                } else if (command == Commands.V4_POSITION_MANAGER_CALL) {
+                    // should only call modifyLiquidities() to mint
+                    _checkV4PositionManagerCall(inputs);
+                    (success, output) = address(V4_POSITION_MANAGER).call{value: address(this).balance}(inputs);
+                } else {
+                    // placeholder area for commands 0x15-0x20
+                    revert InvalidCommandType(command);
+                }
+            }
+        } else {
+            // 0x21 <= command
+            if (command == Commands.EXECUTE_SUB_PLAN) {
+                (bytes calldata _commands, bytes[] calldata _inputs) = inputs.decodeCommandsAndInputs();
+                (success, output) = (address(this)).call(
+                    abi.encodeCall(DispatcherApprovedReentrant.execute, (_commands, _inputs))
+                );
+            } else if (command == CommandsReentrant.APPROVE_REENTRANT) {
+                // APPROVED_REENTRANT: Approve contract to reenter
+                // equivalent:  abi.decode(inputs, (address))
+                address approvedReentrant;
+                assembly {
+                    approvedReentrant := calldataload(inputs.offset)
+                }
+                ApprovedReentrant.set(approvedReentrant);
+            } else if (command == CommandsReentrant.CALL_TARGET) {
+                // CALL_TARGET: Call target contract with data
+                (address target, uint256 value, bytes calldata data) = CalldataCallTargetDecoder.decodeCallTarget(
+                    inputs
+                );
+                (success, output) = payable(target).call{value: value}(data);
+            } else {
+                // placeholder area for commands 0x22-0x3f
+                revert InvalidCommandType(command);
+            }
+        }
+    }
+
+    /// @notice Calculates the recipient address for a command
+    /// @param recipient The recipient or recipient-flag for the command
+    /// @return output The resultant recipient for the command
+    function map(address recipient) internal view returns (address) {
+        if (recipient == ActionConstants.MSG_SENDER) {
+            return msgSender();
+        } else if (recipient == ActionConstants.ADDRESS_THIS) {
+            return address(this);
+        } else {
+            return recipient;
+        }
+    }
+}

--- a/packages/veraswap-sdk/contracts/FlashERC20BalanceCollateral.sol
+++ b/packages/veraswap-sdk/contracts/FlashERC20BalanceCollateral.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {Lock} from "@uniswap/universal-router/contracts/base/Lock.sol";
+import {FlashERC20BalanceDelta} from "./libraries/FlashERC20BalanceDelta.sol";
+
+contract FlashERC20BalanceCollateral {
+    address immutable token;
+
+    /// @notice Computes ERC20 balance delta pre and post execution
+    /// @dev External function requires reentrancy lock, if using Permit2 target MUST NOT be Permit2
+    /// @param target The target call address
+    /// @param value The call value
+    /// @param data The call data
+    /// @return previousBalance The initial balance before execution
+    /// @return nextBalance The new balance after execution
+    /// @return delta Positive means balance increased, negative means balance decreased
+    function flashBalanceDelta(
+        address target,
+        uint256 value,
+        bytes calldata data
+    ) internal returns (uint256 previousBalance, uint256 nextBalance, int256 delta) {
+        return FlashERC20BalanceDelta.flashBalanceDelta(token, address(this), target, value, data);
+    }
+}

--- a/packages/veraswap-sdk/contracts/LockWithApprovedReentrant.sol
+++ b/packages/veraswap-sdk/contracts/LockWithApprovedReentrant.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+import {Locker} from "@uniswap/universal-router/contracts/libraries/Locker.sol";
+import {ApprovedReentrant} from "./libraries/ApprovedReentrant.sol";
+
+/// @title LockWithApprovedReentrant
+/// @notice A contract that provides a reentrancy lock for external calls EXCEPT from an approved reentrant
+contract LockWithApprovedReentrant {
+    /// @notice Thrown when attempting to reenter a locked function from an external caller that is not an approved reentrant
+    error ContractLocked();
+
+    /// @notice Modifier enforcing a reentrancy lock that allows self-reentrancy and reentrancy from an approved reentrant
+    /// @dev If the contract is not locked, use msg.sender as the locker
+    modifier isNotLockedOrApprovedReentrant() {
+        // Apply a reentrancy lock for all external callers EXCEPT for approved reentrant
+        if (msg.sender != address(this)) {
+            if (Locker.isLocked()) {
+                if (msg.sender != ApprovedReentrant.get()) {
+                    revert ContractLocked();
+                }
+                // Caller is approved reentrant, execute
+                // Approved reentrant is NOT cleared and can reenter again
+                _;
+            } else {
+                // Top-level call, lock contract and execute
+                Locker.set(msg.sender);
+                _;
+                ApprovedReentrant.set(address(0)); // Top-level call done, clear approved reentrant
+                Locker.set(address(0));
+            }
+        } else {
+            // The contract is allowed to reenter itself, so the lock is not checked
+            _;
+        }
+    }
+
+    /// @notice return the current approved reentrant of the contract
+    function _getApprovedReentrant() internal view returns (address) {
+        return ApprovedReentrant.get();
+    }
+
+    /// @notice return the current locker of the contract
+    function _getLocker() internal view returns (address) {
+        return Locker.get();
+    }
+}

--- a/packages/veraswap-sdk/contracts/UniversalRouterApprovedReentrant.sol
+++ b/packages/veraswap-sdk/contracts/UniversalRouterApprovedReentrant.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+// Command implementations
+import {RouterParameters} from "@uniswap/universal-router/contracts/types/RouterParameters.sol";
+import {PaymentsImmutables, PaymentsParameters} from "@uniswap/universal-router/contracts/modules/PaymentsImmutables.sol";
+import {UniswapImmutables, UniswapParameters} from "@uniswap/universal-router/contracts/modules/uniswap/UniswapImmutables.sol";
+import {V4SwapRouter} from "@uniswap/universal-router/contracts/modules/uniswap/v4/V4SwapRouter.sol";
+import {Commands} from "@uniswap/universal-router/contracts/libraries/Commands.sol";
+import {IUniversalRouter} from "@uniswap/universal-router/contracts/interfaces/IUniversalRouter.sol";
+import {MigratorImmutables, MigratorParameters} from "@uniswap/universal-router/contracts/modules/MigratorImmutables.sol";
+import {DispatcherApprovedReentrant} from "./DispatcherApprovedReentrant.sol";
+
+/**
+ * Universal Router designed for maximum composability with contracts using TSTORE based callback patterns
+ * Allows the original caller to set an APPROVED_REENTRANT to reenter the router
+ * Combined with CALL_TARGET this enables contracts to execute router commands on behalf of the user (msgSender remains the original locker)
+ *
+ * Consider the use case of a collateral based bridging contract that uses flash accounting.
+ * The goal is to execute a swap from the user to the collateral-based bridging contract via only 2 ERC20 transfers (user => pool, pool => bridge)
+ * and then execute the bridging call to the bridging protocol's messaging contract.
+ *
+ * - User calls UniversalRouter
+ * - msgSender is stored using TSTORE
+ * - Router is locked: only self-reentrancy and approved reentrancy is allowed
+ * - APPROVE_REENTRANT: TSTORE approved reentrant
+ * - CALL_TARGET: Call target contract, most often this contract will reenter the router
+ *
+ * We introduce the following commands
+ * - APPROVE_REENTRANT: Set approved reentrant. Warning: For maximum composability, reentrant can execute ANY command including APPROVE_REENTRANT
+ * - CALL_TARGET: Call target. This does NOT have to be same address as the approved reentrant (though )
+
+ * The following changes are made to Dispatcher and UniversalRouter as DispatcherReentrant and UniversalRouterReentrant.
+ * We have to copy over the code because certain functions are not overridable.
+ * - Add APPROVE_REENTRANT, CALL_TARGET commands to CommandsReentrant.sol
+ * - Update `Dispatch.dispatch()` to implement new commands in DispatcherReentrant.sol
+ * - Update `Dispatch.msgSender()` to from MSG_SENDER
+ * - Replace `Lock.isNotLocked` modifier with `LockWithApprovedReentrant` which has `isNotLockedOrApprovedReentrant` modifier and `setApprovedReentrant`/`getApprovedReentrant` utils  
+ *
+ * The changes introduce the following invariants
+ * - `getLocker` / `msgSender` behaviour are unchanged: the msgSender is ALWAYS the first `msg.sender` value to call `execute` (and "lock")
+ * - `execute` can be called: when unlocked, with self-reentrancy, with approved reentrant
+ */
+contract UniversalRouterApprovedReentrant is IUniversalRouter, DispatcherApprovedReentrant {
+    constructor(
+        RouterParameters memory params
+    )
+        UniswapImmutables(
+            UniswapParameters(params.v2Factory, params.v3Factory, params.pairInitCodeHash, params.poolInitCodeHash)
+        )
+        V4SwapRouter(params.v4PoolManager)
+        PaymentsImmutables(PaymentsParameters(params.permit2, params.weth9))
+        MigratorImmutables(MigratorParameters(params.v3NFTPositionManager, params.v4PositionManager))
+    {}
+
+    modifier checkDeadline(uint256 deadline) {
+        if (block.timestamp > deadline) revert TransactionDeadlinePassed();
+        _;
+    }
+
+    /// @notice To receive ETH from WETH
+    receive() external payable {
+        if (msg.sender != address(WETH9) && msg.sender != address(poolManager)) revert InvalidEthSender();
+    }
+
+    /// @inheritdoc IUniversalRouter
+    function execute(
+        bytes calldata commands,
+        bytes[] calldata inputs,
+        uint256 deadline
+    ) external payable checkDeadline(deadline) {
+        execute(commands, inputs);
+    }
+
+    /// @inheritdoc DispatcherApprovedReentrant
+    function execute(
+        bytes calldata commands,
+        bytes[] calldata inputs
+    ) public payable override isNotLockedOrApprovedReentrant {
+        bool success;
+        bytes memory output;
+        uint256 numCommands = commands.length;
+        if (inputs.length != numCommands) revert LengthMismatch();
+
+        // loop through all given commands, execute them and pass along outputs as defined
+        for (uint256 commandIndex = 0; commandIndex < numCommands; commandIndex++) {
+            bytes1 command = commands[commandIndex];
+
+            bytes calldata input = inputs[commandIndex];
+
+            (success, output) = dispatch(command, input);
+
+            if (!success && successRequired(command)) {
+                revert ExecutionFailed({commandIndex: commandIndex, message: output});
+            }
+        }
+    }
+
+    function successRequired(bytes1 command) internal pure returns (bool) {
+        return command & Commands.FLAG_ALLOW_REVERT == 0;
+    }
+}

--- a/packages/veraswap-sdk/contracts/libraries/ApprovedReentrant.sol
+++ b/packages/veraswap-sdk/contracts/libraries/ApprovedReentrant.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+/// @notice A library to implement an approved reentrant in transient storage.
+/// @dev The approved reentrant's address is stored to allow the contract to know if the caller is approved
+/// TODO: This library can be deleted when we have the transient keyword support in solidity.
+library ApprovedReentrant {
+    // The slot holding the approved reentrant state, transiently. bytes32(uint256(keccak256("ApprovedReentrant")) - 1)
+    bytes32 constant APPROVED_REENTRANT_SLOT = 0x954e40ac94e7c945c409f421f1846b7d735df1d1d7487ba181a55646c5c256fa;
+
+    function set(address approvedReentrant) internal {
+        //TODO: What does this comment mean in Locker.sol???
+        // The locker is always msg.sender or address(0) so does not need to be cleaned
+        assembly ("memory-safe") {
+            tstore(APPROVED_REENTRANT_SLOT, approvedReentrant)
+        }
+    }
+
+    function get() internal view returns (address approvedReentrant) {
+        assembly ("memory-safe") {
+            approvedReentrant := tload(APPROVED_REENTRANT_SLOT)
+        }
+    }
+}

--- a/packages/veraswap-sdk/contracts/libraries/CalldataCallTargetDecoder.sol
+++ b/packages/veraswap-sdk/contracts/libraries/CalldataCallTargetDecoder.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title Library for abi decoding in calldata
+library CalldataCallTargetDecoder {
+    using CalldataCallTargetDecoder for bytes;
+
+    error SliceOutOfBounds();
+
+    /// @notice mask used for offsets and lengths to ensure no overflow
+    /// @dev no sane abi encoding will pass in an offset or length greater than type(uint32).max
+    ///      (note that this does deviate from standard solidity behavior and offsets/lengths will
+    ///      be interpreted as mod type(uint32).max which will only impact malicious/buggy callers)
+    uint256 constant OFFSET_OR_LENGTH_MASK = 0xffffffff;
+    uint256 constant OFFSET_OR_LENGTH_MASK_AND_WORD_ALIGN = 0xffffffe0;
+
+    /// @notice equivalent to SliceOutOfBounds.selector, stored in least-significant bits
+    uint256 constant SLICE_ERROR_SELECTOR = 0x3b99b53d;
+
+    /// @dev equivalent to: abi.decode(params, (address, uint256, bytes)) in calldata
+    function decodeCallTarget(
+        bytes calldata params
+    ) internal pure returns (address target, uint256 value, bytes calldata data) {
+        // no length check performed, as there is a length check in `toBytes`
+        assembly ("memory-safe") {
+            target := calldataload(params.offset)
+            value := calldataload(add(params.offset, 0x20))
+        }
+
+        data = params.toBytes(2);
+    }
+
+    /// @notice Decode the `_arg`-th element in `_bytes` as `bytes`
+    /// @param _bytes The input bytes string to extract a bytes string from
+    /// @param _arg The index of the argument to extract
+    function toBytes(bytes calldata _bytes, uint256 _arg) internal pure returns (bytes calldata res) {
+        uint256 length;
+        assembly ("memory-safe") {
+            // The offset of the `_arg`-th element is `32 * arg`, which stores the offset of the length pointer.
+            // shl(5, x) is equivalent to mul(32, x)
+            let lengthPtr := add(
+                _bytes.offset,
+                and(calldataload(add(_bytes.offset, shl(5, _arg))), OFFSET_OR_LENGTH_MASK)
+            )
+            // the number of bytes in the bytes string
+            length := and(calldataload(lengthPtr), OFFSET_OR_LENGTH_MASK)
+            // the offset where the bytes string begins
+            let offset := add(lengthPtr, 0x20)
+            // assign the return parameters
+            res.length := length
+            res.offset := offset
+
+            // if the provided bytes string isnt as long as the encoding says, revert
+            if lt(add(_bytes.length, _bytes.offset), add(length, offset)) {
+                mstore(0, SLICE_ERROR_SELECTOR)
+                revert(0x1c, 4)
+            }
+        }
+    }
+}

--- a/packages/veraswap-sdk/contracts/libraries/CommandsReentrant.sol
+++ b/packages/veraswap-sdk/contracts/libraries/CommandsReentrant.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+/// @title Commands with added APPROVE_REENTRANT, CALL_TARGET commands
+/// @notice Command Flags used to decode commands
+library CommandsReentrant {
+    // Masks to extract certain bits of commands
+    bytes1 internal constant FLAG_ALLOW_REVERT = 0x80;
+    bytes1 internal constant COMMAND_TYPE_MASK = 0x3f;
+
+    // Command Types. Maximum supported command at this moment is 0x3f.
+    // The commands are executed in nested if blocks to minimise gas consumption
+
+    // Command Types where value<=0x07, executed in the first nested-if block
+    uint256 constant V3_SWAP_EXACT_IN = 0x00;
+    uint256 constant V3_SWAP_EXACT_OUT = 0x01;
+    uint256 constant PERMIT2_TRANSFER_FROM = 0x02;
+    uint256 constant PERMIT2_PERMIT_BATCH = 0x03;
+    uint256 constant SWEEP = 0x04;
+    uint256 constant TRANSFER = 0x05;
+    uint256 constant PAY_PORTION = 0x06;
+    // COMMAND_PLACEHOLDER = 0x07;
+
+    // Command Types where 0x08<=value<=0x0f, executed in the second nested-if block
+    uint256 constant V2_SWAP_EXACT_IN = 0x08;
+    uint256 constant V2_SWAP_EXACT_OUT = 0x09;
+    uint256 constant PERMIT2_PERMIT = 0x0a;
+    uint256 constant WRAP_ETH = 0x0b;
+    uint256 constant UNWRAP_WETH = 0x0c;
+    uint256 constant PERMIT2_TRANSFER_FROM_BATCH = 0x0d;
+    uint256 constant BALANCE_CHECK_ERC20 = 0x0e;
+    // COMMAND_PLACEHOLDER = 0x0f;
+
+    // Command Types where 0x10<=value<=0x20, executed in the third nested-if block
+    uint256 constant V4_SWAP = 0x10;
+    uint256 constant V3_POSITION_MANAGER_PERMIT = 0x11;
+    uint256 constant V3_POSITION_MANAGER_CALL = 0x12;
+    uint256 constant V4_INITIALIZE_POOL = 0x13;
+    uint256 constant V4_POSITION_MANAGER_CALL = 0x14;
+    // COMMAND_PLACEHOLDER = 0x15 -> 0x20
+
+    // Command Types where 0x21<=value<=0x3f
+    uint256 constant EXECUTE_SUB_PLAN = 0x21;
+    // COMMAND_PLACEHOLDER for 0x22 to 0x3f
+    // Reentrant commands
+    uint256 constant APPROVE_REENTRANT = 0x22;
+    uint256 constant CALL_TARGET = 0x23;
+}

--- a/packages/veraswap-sdk/contracts/libraries/FlashERC20BalanceDelta.sol
+++ b/packages/veraswap-sdk/contracts/libraries/FlashERC20BalanceDelta.sol
@@ -6,13 +6,14 @@ import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 /**
  * Modify ERC20 balance using flash accounting. Can be used to accept ERC20 deposits without the need to pull tokens using transferFrom.
  * - Get previous ERC20 balance
- * - Execute arbitrary call data (excluding erc20)
+ * - Execute arbitrary call data (excluding erc20 & PERMIT2)
  * - Get current ERC20 balance
  * WARNING: External function requires reentrancy lock
- * WARNING: If using Permit2, target MUST NOT be Permit2
  */
 library FlashERC20BalanceDelta {
-    error TargetIsToken();
+    error TargetIsTokenOrPermit2();
+
+    address constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
 
     /// @notice Computes ERC20 balance delta of an account pre and post execution
     /// @dev External function requires reentrancy lock, if using Permit2 target MUST NOT be Permit2
@@ -31,7 +32,7 @@ library FlashERC20BalanceDelta {
         uint256 value,
         bytes calldata data
     ) internal returns (uint256 previousBalance, uint256 nextBalance, int256 delta) {
-        if (target == token) revert TargetIsToken();
+        if (target == token) revert TargetIsTokenOrPermit2();
 
         previousBalance = IERC20(token).balanceOf(account);
         target.call{value: value}(data);

--- a/packages/veraswap-sdk/contracts/libraries/FlashERC20BalanceDelta.sol
+++ b/packages/veraswap-sdk/contracts/libraries/FlashERC20BalanceDelta.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+/**
+ * Modify ERC20 balance using flash accounting. Can be used to accept ERC20 deposits without the need to pull tokens using transferFrom.
+ * - Get previous ERC20 balance
+ * - Execute arbitrary call data (excluding erc20)
+ * - Get current ERC20 balance
+ * WARNING: External function requires reentrancy lock
+ * WARNING: If using Permit2, target MUST NOT be Permit2
+ */
+library FlashERC20BalanceDelta {
+    error TargetIsToken();
+
+    /// @notice Computes ERC20 balance delta pre and post execution
+    /// @dev External function requires reentrancy lock, if using Permit2 target MUST NOT be Permit2
+    /// @param token The token balance to fetch
+    /// @param target The target call address
+    /// @param value The call value
+    /// @param data The call data
+    /// @return previousBalance The initial balance before execution
+    /// @return nextBalance The new balance after execution
+    /// @return delta Positive means balance increased, negative means balance decreased
+    function flashBalanceDelta(
+        address token,
+        address target,
+        uint256 value,
+        bytes calldata data
+    ) internal returns (uint256 prevBalance, uint256 currBalance, int256 delta) {
+        if (target == token) revert TargetIsToken();
+
+        prevBalance = IERC20(token).balanceOf();
+        target.call{value: value}(data);
+        currBalance = IERC20(token).balanceOf();
+
+        delta = currBalance - prevBalance;
+    }
+}

--- a/packages/veraswap-sdk/foundry.toml
+++ b/packages/veraswap-sdk/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-src = "src"
+src = "contracts"
 out = "out"
 libs = ["lib"]
 ffi = true

--- a/packages/veraswap-sdk/script/DeployRouterApprovedReentrant.s.sol
+++ b/packages/veraswap-sdk/script/DeployRouterApprovedReentrant.s.sol
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "forge-std/Script.sol";
+import "forge-std/console2.sol";
+import "forge-std/Test.sol";
+
+import {VmSafe} from "forge-std/Vm.sol";
+
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
+
+import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
+
+import {PoolManager} from "@uniswap/v4-core/src/PoolManager.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Constants} from "@uniswap/v4-core/test/utils/Constants.sol";
+
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {CurrencyLibrary, Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {LiquidityAmounts} from "@uniswap/v4-core/test/utils/LiquidityAmounts.sol";
+
+import {IPositionManager} from "@uniswap/v4-periphery/src/interfaces/IPositionManager.sol";
+import {PositionManager} from "@uniswap/v4-periphery/src/PositionManager.sol";
+import {IPositionDescriptor} from "@uniswap/v4-periphery/src/interfaces/IPositionDescriptor.sol";
+import {IV4Router} from "@uniswap/v4-periphery/src/interfaces/IV4Router.sol";
+import {IV4Quoter} from "@uniswap/v4-periphery/src/interfaces/IV4Quoter.sol";
+import {IStateView} from "@uniswap/v4-periphery/src/interfaces/IStateView.sol";
+import {IWETH9} from "@uniswap/v4-periphery/src/interfaces/external/IWETH9.sol";
+import {Actions} from "@uniswap/v4-periphery/src/libraries/Actions.sol";
+
+import {RouterParameters} from "@uniswap/universal-router/contracts/types/RouterParameters.sol";
+import {UnsupportedProtocol} from "@uniswap/universal-router/contracts/deploy/UnsupportedProtocol.sol";
+import {Commands} from "@uniswap/universal-router/contracts/libraries/Commands.sol";
+import {V4Quoter} from "@uniswap/universal-router/lib/v4-periphery/src/lens/V4Quoter.sol";
+import {StateView} from "@uniswap/universal-router/lib/v4-periphery/src/lens/StateView.sol";
+
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import "@uniswap/v4-core/src/types/Currency.sol";
+import {IUniversalRouter} from "@uniswap/universal-router/contracts/interfaces/IUniversalRouter.sol";
+
+import {DeployPermit2} from "../test/utils/forks/DeployPermit2.sol";
+import {DeployCreate2Deployer} from "../test/utils/forks/DeployCreate2Deployer.sol";
+import {UniversalRouterApprovedReentrant} from "../contracts/UniversalRouterApprovedReentrant.sol";
+import {CommandsReentrant} from "../contracts/libraries/CommandsReentrant.sol";
+import {Execute} from "./Execute.sol";
+
+struct UniswapContracts {
+    IAllowanceTransfer permit2;
+    UnsupportedProtocol unsupported;
+    IPoolManager v4PoolManager;
+    IPositionManager v4PositionManager;
+    IUniversalRouter router;
+    IV4Quoter v4Quoter;
+    IStateView stateView;
+}
+
+/// @notice Forge script for deploying v4 & hooks to **anvil**
+/// @dev This script only works on an anvil RPC because v4 exceeds bytecode limits
+contract DeployRouterApprovedReentrant is Script, Test, DeployPermit2 {
+    using CurrencyLibrary for Currency;
+
+    bytes32 constant BYTES32_ZERO = bytes32(0);
+    bytes constant ZERO_BYTES = new bytes(0);
+
+    function setUp() public {}
+
+    function run() external {
+        vm.startBroadcast();
+        UniswapContracts memory contracts = deployUniswapContracts();
+
+        console2.log("permit2:", address(contracts.permit2));
+        // console2.log("weth9:", params.weth9);
+        // console2.log("v2Factory:", params.v2Factory);
+        // console2.log("v3Factory:", params.v3Factory);
+        console2.log("v4PoolManager:", address(contracts.v4PoolManager));
+        // console2.log("v3NFTPositionManager:", params.v3NFTPositionManager);
+        console2.log("v4PositionManager:", address(contracts.v4PositionManager));
+        console2.log("router:", address(contracts.router));
+        console2.log("v4Quoter:", address(contracts.v4Quoter));
+        console2.log("stateView:", address(contracts.stateView));
+
+        PoolKey memory poolKey = createPool(contracts);
+        testLifeCycle(contracts, poolKey);
+
+        vm.stopBroadcast();
+    }
+
+    function createPool(UniswapContracts memory contracts) public returns (PoolKey memory poolKey) {
+        // Deploy Tokens
+        MockERC20 tokenA = new MockERC20{salt: BYTES32_ZERO}("MockA", "A", 18);
+        MockERC20 tokenB = new MockERC20{salt: BYTES32_ZERO}("MockB", "B", 18);
+        console2.log("MockA:", address(tokenA));
+        console2.log("MockB:", address(tokenB));
+
+        MockERC20 token0;
+        MockERC20 token1;
+        if (uint160(address(tokenA)) < uint160(address(tokenB))) {
+            token0 = tokenA;
+            token1 = tokenB;
+        } else {
+            token0 = tokenB;
+            token1 = tokenA;
+        }
+        // Mint
+        token0.mint(msg.sender, 100_000 ether);
+        token1.mint(msg.sender, 100_000 ether);
+        // Approve Permit2
+        token0.approve(address(permit2), type(uint256).max);
+        token1.approve(address(permit2), type(uint256).max);
+        // Approve PositionManager using Permit2
+        permit2.approve(address(token0), address(contracts.v4PositionManager), type(uint160).max, type(uint48).max);
+        permit2.approve(address(token1), address(contracts.v4PositionManager), type(uint160).max, type(uint48).max);
+        // Approve UnversalRouter using Permit2
+        permit2.approve(address(token0), address(contracts.router), type(uint160).max, type(uint48).max);
+        permit2.approve(address(token1), address(contracts.router), type(uint160).max, type(uint48).max);
+
+        // Initialize Pool & Mint Liquidity
+        // See https://docs.uniswap.org/contracts/v4/quickstart/create-pool
+        bytes[] memory multicallParams = new bytes[](2);
+
+        // 1. Initialize the parameters provided to multicall()
+        int24 tickSpacing = 60;
+        poolKey = PoolKey(
+            Currency.wrap(address(token0)),
+            Currency.wrap(address(token1)),
+            3000,
+            tickSpacing,
+            IHooks(address(0))
+        );
+        // 3. Encode the initializePool parameters
+        uint160 startingPrice = Constants.SQRT_PRICE_1_1;
+        multicallParams[0] = abi.encodeWithSelector(
+            contracts.v4PositionManager.initializePool.selector,
+            poolKey,
+            startingPrice
+        );
+        // 4. Initialize the mint-liquidity parameters
+        bytes memory mintActions = abi.encodePacked(uint8(Actions.MINT_POSITION), uint8(Actions.SETTLE_PAIR));
+        // 5. Encode the MINT_POSITION parameters
+        int24 tickLower = (TickMath.getTickAtSqrtPrice(Constants.SQRT_PRICE_1_2) / tickSpacing) * tickSpacing;
+        int24 tickUpper = (TickMath.getTickAtSqrtPrice(Constants.SQRT_PRICE_2_1) / tickSpacing) * tickSpacing;
+        uint256 liquidity = LiquidityAmounts.getLiquidityForAmounts(
+            startingPrice,
+            TickMath.getSqrtPriceAtTick(tickLower),
+            TickMath.getSqrtPriceAtTick(tickUpper),
+            100 ether,
+            100 ether
+        ); // Encodes a 100/100 position at 1:1 price across the entire tick range
+        bytes[] memory mintParams = new bytes[](2);
+        mintParams[0] = abi.encode(
+            poolKey,
+            tickLower,
+            tickUpper,
+            liquidity,
+            50_000 ether,
+            50_000 ether,
+            msg.sender,
+            ZERO_BYTES
+        );
+        // 6. Encode the SETTLE_PAIR parameters
+        mintParams[1] = abi.encode(poolKey.currency0, poolKey.currency1);
+        // 7. Encode the modifyLiquidites call
+        uint256 deadline = block.timestamp + 60;
+        multicallParams[1] = abi.encodeWithSelector(
+            contracts.v4PositionManager.modifyLiquidities.selector,
+            abi.encode(mintActions, mintParams),
+            deadline
+        );
+        // 8. Approve the tokens
+        // Done Above
+        // 9. Execute the multicall
+        contracts.v4PositionManager.multicall(multicallParams);
+        uint256 currentLiquidity = contracts.stateView.getLiquidity(PoolIdLibrary.toId(poolKey));
+        assertGt(currentLiquidity, 0);
+
+        console2.log("liquidity:", currentLiquidity);
+        console2.log("tokenA:", tokenA.balanceOf(msg.sender));
+        console2.log("tokenB:", tokenB.balanceOf(msg.sender));
+    }
+
+    function testLifeCycle(UniswapContracts memory contracts, PoolKey memory poolKey) public {
+        console2.log("currency0:", poolKey.currency0.balanceOf(msg.sender));
+        console2.log("currency1:", poolKey.currency1.balanceOf(msg.sender));
+
+        // Dummy contract that will be approved reentrant
+        Execute executor = new Execute();
+
+        // Commands sent from locker to Universal Router
+        bytes memory routerCommands0 = abi.encodePacked(
+            uint8(CommandsReentrant.APPROVE_REENTRANT),
+            uint8(CommandsReentrant.CALL_TARGET)
+        );
+        bytes[] memory routerInputs0 = new bytes[](2);
+
+        // Swap
+        // See https://docs.uniswap.org/contracts/v4/quickstart/swap
+        // 3.2: Encoding the Swap Command
+
+        // Commands sent from executor to Universal Router (acting as locker)
+        bytes memory routerCommands1 = abi.encodePacked(uint8(Commands.V4_SWAP));
+        bytes[] memory routerInputs1 = new bytes[](1);
+        // 3.3: Action Encoding
+        // Encode V4Router actions
+        bytes memory swapActions = abi.encodePacked(
+            uint8(Actions.SWAP_EXACT_IN_SINGLE),
+            uint8(Actions.SETTLE_ALL),
+            uint8(Actions.TAKE_ALL)
+        );
+        // 3.4: Preparing the Swap Inputs
+        bytes[] memory swapParams = new bytes[](3);
+        // SWAP_EXACT_IN_SINGLE: swap configuration
+        uint128 amountIn = 1_000_000;
+        uint128 minAmountOut = 0;
+        swapParams[0] = abi.encode(
+            IV4Router.ExactInputSingleParams({
+                poolKey: poolKey,
+                zeroForOne: true, // true if we're swapping token0 for token1
+                amountIn: amountIn, // amount of tokens we're swapping
+                amountOutMinimum: minAmountOut, // minimum amount we expect to receive
+                hookData: bytes("") // no hook data needed
+            })
+        );
+        // SETTLE_ALL: specify input tokens for the swap
+        swapParams[1] = abi.encode(poolKey.currency0, amountIn);
+        // TAKE_ALL: specify output tokens from the swap
+        swapParams[2] = abi.encode(poolKey.currency1, minAmountOut);
+        // 3.5: Executing the Swap
+        // Combine actions and params into inputs
+        routerInputs1[0] = abi.encode(swapActions, swapParams);
+
+        // Encode the executor address as approved
+        // APPROVE_REENTRANT input
+        routerInputs0[0] = abi.encode(address(executor));
+        // Encode the executor call to universal router
+        // Executor => Router (swap commands)
+        bytes memory executorRouterCall = abi.encodeWithSelector(
+            contracts.router.execute.selector,
+            routerCommands1,
+            routerInputs1,
+            block.timestamp + 60
+        );
+        // Router => Executor (approve and call target commands)
+        bytes memory routerExecutorCall = abi.encodeWithSelector(
+            executor.execute.selector,
+            address(contracts.router),
+            0,
+            executorRouterCall
+        );
+        // CALL_TARGET input
+        routerInputs0[1] = abi.encode(address(executor), 0, routerExecutorCall);
+
+        // Execute the swap
+        contracts.router.execute(routerCommands0, routerInputs0, block.timestamp + 60);
+
+        // 3.6: (Optional) Verifying the Swap Output
+        console2.log("currency0:", poolKey.currency0.balanceOf(msg.sender));
+        console2.log("currency1:", poolKey.currency1.balanceOf(msg.sender));
+    }
+
+    function deployUniswapContracts() public returns (UniswapContracts memory) {
+        // deployCreate2Deployer();
+        IAllowanceTransfer permit2 = deployPermit2();
+
+        UnsupportedProtocol unsupported = new UnsupportedProtocol{salt: BYTES32_ZERO}();
+
+        IPoolManager v4PoolManager = IPoolManager(address(new PoolManager{salt: BYTES32_ZERO}(address(0))));
+
+        IPositionManager v4PositionManager = IPositionManager(
+            new PositionManager{salt: BYTES32_ZERO}(
+                v4PoolManager,
+                permit2,
+                300_000,
+                IPositionDescriptor(address(0)),
+                IWETH9(address(0))
+            )
+        );
+
+        RouterParameters memory routerParams = RouterParameters({
+            permit2: address(permit2),
+            weth9: address(0),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: BYTES32_ZERO,
+            poolInitCodeHash: BYTES32_ZERO,
+            v4PoolManager: address(v4PoolManager),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(v4PositionManager)
+        });
+
+        IUniversalRouter router = new UniversalRouterApprovedReentrant{salt: BYTES32_ZERO}(routerParams);
+        IV4Quoter v4Quoter = IV4Quoter(address(new V4Quoter{salt: BYTES32_ZERO}(v4PoolManager)));
+        IStateView stateView = IStateView(address(new StateView{salt: BYTES32_ZERO}(v4PoolManager)));
+
+        return
+            UniswapContracts({
+                permit2: permit2,
+                unsupported: unsupported,
+                v4PoolManager: v4PoolManager,
+                v4PositionManager: v4PositionManager,
+                router: router,
+                v4Quoter: v4Quoter,
+                stateView: stateView
+            });
+    }
+}

--- a/packages/veraswap-sdk/script/Execute.sol
+++ b/packages/veraswap-sdk/script/Execute.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+// Dummy contract that will execute swap on behalf of user
+contract Execute {
+    function execute(address target, uint256 value, bytes calldata data) external {
+        target.call{value: value}(data);
+    }
+}


### PR DESCRIPTION
- Add a new custom Uniswap Universal Router that enables users to "delegate" execution to approved contracts and "call" custom target contracts (excluding Permit2). This enables users to call the router, then call a custom contract, and then have that contract execute swaps on their behalf.
- Add FlashERC20BalanceDelta, a simple library that computes ERC20 balance between an arbitrary call execution (excluding the token and PERMIT2)