### PR TITLE
BridgeSwap Transaction Helpers

### DIFF
--- a/packages/veraswap-sdk/package.json
+++ b/packages/veraswap-sdk/package.json
@@ -96,6 +96,7 @@
     "@uniswap/v4-periphery": "1.0.1",
     "@uniswap/v4-sdk": "^1.21.2",
     "@wagmi/core": "^2.9.10",
+    "@wagmi/connectors": "^5.7.12",
     "@zerodev/sdk": "^5.4.26",
     "@zerodev/ecdsa-validator": "^5.4.4",
     "abitype": "1.0.8",

--- a/packages/veraswap-sdk/src/calls/getBalance.test.ts
+++ b/packages/veraswap-sdk/src/calls/getBalance.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import { getAnvilAccount } from "@veraswap/anvil-account";
+import { createConfig, getBalance, http } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+import { getBalanceQueryOptions } from "wagmi/query";
+
+import { opChainL1, opChainL1Client } from "../chains/supersim.js";
+
+/**
+ * Simple example showcasing how to use cached calls using QueryClient and wagmi/core
+ */
+describe("calls/getBalance.test.ts", function () {
+    const anvilAccount = getAnvilAccount();
+    const config = createConfig({
+        chains: [opChainL1],
+        transports: {
+            [opChainL1.id]: http(),
+        },
+    });
+    const queryClient = new QueryClient();
+
+    test("getBalance", async () => {
+        // Example test fetching balance in 3 ways
+        // viem
+        const viemResult = await opChainL1Client.getBalance({
+            address: anvilAccount.address,
+        });
+        // wagmi/core: calls viem via global config, accepts chainId as parameter
+        const wagmiResult = await getBalance(config, { chainId: opChainL1.id, address: anvilAccount.address });
+        expect(wagmiResult.value).toBe(viemResult);
+        // tanstack/query: call wagmi/core logic via queryOptions supporting custom caching logic
+        const queryResult = await queryClient.fetchQuery(
+            getBalanceQueryOptions(config, { chainId: opChainL1.id, address: anvilAccount.address }),
+        );
+        expect(queryResult.value).toBe(viemResult);
+    });
+});

--- a/packages/veraswap-sdk/src/calls/getBridgeSwapCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getBridgeSwapCalls.ts
@@ -1,0 +1,30 @@
+import { QueryClient } from "@tanstack/react-query";
+import { Address, Hex } from "viem";
+import { Config } from "wagmi";
+import { GetCallsParams, GetCallsReturnType } from "./getCalls.js";
+import { getTransferRemoteCalls } from "./getTransferRemoteCalls.js";
+
+export interface GetBridgeSwapCallsParams extends GetCallsParams {
+    funder: Address;
+    tokenStandard: "HypERC20" | "HypERC20Collateral";
+    token: Address;
+    destination: number;
+    recipient: Address;
+    amount: bigint;
+    hookMetadata?: Hex;
+    hook?: Address;
+}
+
+/**
+ * Get bridge swap calls
+ * @param _queryClient
+ * @param _wagmiConfig
+ */
+export function getBridgeSwapCalls(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetBridgeSwapCallsParams,
+): Promise<GetCallsReturnType> {
+    //TODO: Add swap calls
+    return getTransferRemoteCalls(queryClient, wagmiConfig, params);
+}

--- a/packages/veraswap-sdk/src/calls/getCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getCalls.ts
@@ -4,7 +4,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { Config } from "wagmi";
 
 /**
- * Common params for all `get*Calls` functions
+ * Common params for all `get...Calls` functions with `chainId, account` params
  */
 export interface GetCallsParams {
     chainId: number;
@@ -12,7 +12,7 @@ export interface GetCallsParams {
 }
 
 /**
- * Common return type for all `get*Calls` functio
+ * Common return type for all `get...Calls` functions that return list of `calls`
  */
 export interface GetCallsReturnType {
     calls: CallArgs[];

--- a/packages/veraswap-sdk/src/calls/getCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getCalls.ts
@@ -1,0 +1,30 @@
+import { Address } from "viem";
+import { CallArgs } from "../smartaccount/ExecLib.js";
+import { QueryClient } from "@tanstack/react-query";
+import { Config } from "wagmi";
+
+/**
+ * Common params for all `get*Calls` functions
+ */
+export interface GetCallsParams {
+    chainId: number;
+    account: Address;
+}
+
+/**
+ * Common return type for all `get*Calls` functio
+ */
+export interface GetCallsReturnType {
+    calls: CallArgs[];
+}
+
+/**
+ * Get calls function type
+ * Note: `satisfies` keyword does not work on function declarations so just here for informational purposes
+ * https://github.com/microsoft/TypeScript/issues/51556
+ */
+export type GetCallsFn<P extends GetCallsParams = GetCallsParams, R extends GetCallsReturnType = GetCallsReturnType> = (
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: P,
+) => R;

--- a/packages/veraswap-sdk/src/calls/getERC20ApproveCalls.test.ts
+++ b/packages/veraswap-sdk/src/calls/getERC20ApproveCalls.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test, beforeEach } from "vitest";
+import { getAnvilAccount } from "@veraswap/anvil-account";
+import { createConfig, http } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+
+import { opChainL1, opChainL1Client } from "../chains/supersim.js";
+
+import { localMockTokens } from "../constants/tokens.js";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { Account, Chain, createWalletClient, parseEther, Transport, WalletClient } from "viem";
+import { MockERC20 } from "../artifacts/MockERC20.js";
+import { getERC20ApproveCalls } from "./getERC20ApproveCalls.js";
+import { IERC20 } from "../artifacts/IERC20.js";
+
+describe("calls/getERC20ApproveCall.test.ts", function () {
+    const config = createConfig({
+        chains: [opChainL1],
+        transports: {
+            [opChainL1.id]: http(),
+        },
+    });
+    const queryClient = new QueryClient();
+
+    let account: Account;
+    let accountClient: WalletClient<Transport, Chain, Account>;
+    let spender: Account;
+
+    const tokenA = localMockTokens[0];
+
+    beforeEach(async () => {
+        const anvilAccount = getAnvilAccount();
+        const anvilClient = createWalletClient({
+            account: anvilAccount,
+            chain: opChainL1Client.chain,
+            transport: http(),
+        });
+
+        account = privateKeyToAccount(generatePrivateKey());
+        accountClient = createWalletClient({
+            account,
+            chain: opChainL1Client.chain,
+            transport: http(),
+        });
+        spender = privateKeyToAccount(generatePrivateKey());
+        // Fund account with Ether
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.sendTransaction({
+                to: account.address,
+                value: parseEther("1"),
+            }),
+        });
+        // Fund account with Token A
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.writeContract({
+                address: tokenA.address,
+                abi: MockERC20.abi,
+                functionName: "mint",
+                args: [account.address, parseEther("100")],
+            }),
+        });
+    });
+    test("getERC20ApproveCalls", async () => {
+        // Approve from account to spender
+        const approveCall = await getERC20ApproveCalls(queryClient, config, {
+            chainId: opChainL1.id,
+            token: tokenA.address,
+            account: account.address,
+            spender: spender.address,
+            minAmount: 1n,
+        });
+        expect(approveCall.allowance).toBe(0n);
+        expect(approveCall.calls.length).toBe(1);
+
+        // Send from account `IAllowance.approve(token, spender, approveAmount, approveExpiration)`
+        expect(approveCall.calls[0]).toBeDefined();
+        expect(approveCall.calls[0].to).toBe(tokenA.address);
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await accountClient.sendTransaction(approveCall.calls[0]),
+        });
+
+        // Check allowance of spender
+        const allowance = await opChainL1Client.readContract({
+            address: tokenA.address,
+            abi: IERC20.abi,
+            functionName: "allowance",
+            args: [account.address, spender.address],
+        });
+        expect(allowance).toBe(1n);
+    });
+});

--- a/packages/veraswap-sdk/src/calls/getERC20ApproveCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getERC20ApproveCalls.ts
@@ -20,6 +20,7 @@ export interface GetERC20ApproveCallsReturnType extends GetCallsReturnType {
 }
 
 /**
+ * Approve tokens from `account` to `spender`
  * Get spender allowance and return `IERC20.approve(account, spender)` call if allowance below `minAmount`
  * @dev Assumes `token.balanceOf(account) > minAmount`
  * @param queryClient

--- a/packages/veraswap-sdk/src/calls/getERC20ApproveCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getERC20ApproveCalls.ts
@@ -1,0 +1,64 @@
+import { Config } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+
+import { readContractQueryOptions } from "wagmi/query";
+import { Address, encodeFunctionData } from "viem";
+import invariant from "tiny-invariant";
+
+import { IERC20 } from "../artifacts/IERC20.js";
+import { GetCallsParams, GetCallsReturnType } from "./getCalls.js";
+
+export interface GetERC20ApproveCallsParams extends GetCallsParams {
+    token: Address;
+    spender: Address;
+    minAmount: bigint;
+    approveAmount?: bigint;
+}
+
+export interface GetERC20ApproveCallsReturnType extends GetCallsReturnType {
+    allowance: bigint;
+}
+
+/**
+ * Get spender allowance and return `IERC20.approve` call if below minAmount
+ * @dev Make sure to check `owner` balance is sufficient beforehand (if needed)
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ */
+export async function getERC20ApproveCalls(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetERC20ApproveCallsParams,
+): Promise<GetERC20ApproveCallsReturnType> {
+    const { chainId, token, account, spender, minAmount } = params;
+    // Amount to approve if current allowance < minAmount
+    const approveAmount = params.approveAmount ?? minAmount;
+    invariant(approveAmount >= minAmount, "approveAmount must be >= minAmount");
+
+    const allowance = await queryClient.fetchQuery(
+        readContractQueryOptions(wagmiConfig, {
+            chainId,
+            address: token,
+            abi: IERC20.abi,
+            functionName: "allowance",
+            args: [account, spender],
+        }),
+    );
+
+    if (allowance >= minAmount) {
+        return { allowance, calls: [] };
+    }
+
+    const call = {
+        to: token,
+        data: encodeFunctionData({
+            abi: IERC20.abi,
+            functionName: "approve",
+            args: [spender, approveAmount],
+        }),
+        value: 0n,
+    };
+
+    return { allowance, calls: [call] };
+}

--- a/packages/veraswap-sdk/src/calls/getERC20ApproveCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getERC20ApproveCalls.ts
@@ -20,8 +20,8 @@ export interface GetERC20ApproveCallsReturnType extends GetCallsReturnType {
 }
 
 /**
- * Get spender allowance and return `IERC20.approve` call if below minAmount
- * @dev Make sure to check `owner` balance is sufficient beforehand (if needed)
+ * Get spender allowance and return `IERC20.approve(account, spender)` call if allowance below `minAmount`
+ * @dev Assumes `token.balanceOf(account) > minAmount`
  * @param queryClient
  * @param wagmiConfig
  * @param params

--- a/packages/veraswap-sdk/src/calls/getERC20TransferFromCalls.test.ts
+++ b/packages/veraswap-sdk/src/calls/getERC20TransferFromCalls.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test, beforeEach, beforeAll } from "vitest";
+import { getAnvilAccount } from "@veraswap/anvil-account";
+import { connect, createConfig, http } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+import { mock } from "@wagmi/connectors";
+
+import { opChainL1, opChainL1Client } from "../chains/supersim.js";
+
+import { localMockTokens } from "../constants/tokens.js";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { Account, Chain, createWalletClient, parseEther, Transport, WalletClient } from "viem";
+import { IERC20 } from "../artifacts/IERC20.js";
+import { getERC20TransferFromCalls } from "./getERC20TransferFromCalls.js";
+
+describe("calls/getERC20TransferFromCalls.test.ts", function () {
+    const anvilAccount = getAnvilAccount();
+    const anvilClient = createWalletClient({
+        account: anvilAccount,
+        chain: opChainL1Client.chain,
+        transport: http(),
+    });
+
+    // Mock connector to use wagmi signing
+    const mockConnector = mock({
+        accounts: [
+            anvilAccount.address, //only works because anvil will allow RPC based signing (connector does not use in-memory pkey)
+        ],
+    });
+    const config = createConfig({
+        chains: [opChainL1],
+        transports: {
+            [opChainL1.id]: http(),
+        },
+        connectors: [mockConnector],
+    });
+    const queryClient = new QueryClient();
+
+    let account: Account;
+    let accountClient: WalletClient<Transport, Chain, Account>;
+
+    const tokenA = localMockTokens[0];
+    // const tokenAHypERC20Collateral = LOCAL_TOKENS[0];
+
+    beforeAll(async () => {
+        await connect(config, {
+            chainId: opChainL1.id,
+            connector: mockConnector,
+        });
+    });
+
+    beforeEach(async () => {
+        account = privateKeyToAccount(generatePrivateKey());
+        accountClient = createWalletClient({
+            account,
+            chain: opChainL1Client.chain,
+            transport: http(),
+        });
+        // Fund account
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.sendTransaction({
+                to: account.address,
+                value: parseEther("1"),
+            }),
+        });
+    });
+
+    test("ERC20.approve", async () => {
+        // Approve account as spender
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.writeContract({
+                address: tokenA.address,
+                abi: IERC20.abi,
+                functionName: "approve",
+                args: [account.address, 1n],
+            }),
+        });
+
+        // Transfer from anvilAccount to account
+        const transferFromCall = await getERC20TransferFromCalls(queryClient, config, {
+            chainId: opChainL1.id,
+            token: tokenA.address,
+            account: account.address,
+            funder: anvilAccount.address,
+            minAmount: 1n,
+        });
+        expect(transferFromCall.balance).toBe(0n);
+        expect(transferFromCall.calls.length).toBe(1);
+
+        // Send from account `IERC20.transferFrom(anvilAccount, account, 1n)`
+        expect(transferFromCall.calls[0]).toBeDefined();
+        expect(transferFromCall.calls[0].to).toBe(tokenA.address);
+
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await accountClient.sendTransaction(transferFromCall.calls[0]),
+        });
+
+        // Check balance of account
+        const balance = await opChainL1Client.readContract({
+            address: tokenA.address,
+            abi: IERC20.abi,
+            functionName: "balanceOf",
+            args: [account.address],
+        });
+        expect(balance).toBe(1n);
+    });
+});

--- a/packages/veraswap-sdk/src/calls/getERC20TransferFromCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getERC20TransferFromCalls.ts
@@ -1,0 +1,109 @@
+import { Config } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+
+import { readContractQueryOptions } from "wagmi/query";
+import { Address, encodeFunctionData } from "viem";
+import invariant from "tiny-invariant";
+
+import { IERC20 } from "../artifacts/IERC20.js";
+import { IAllowanceTransfer } from "../artifacts/IAllowanceTransfer.js";
+import { PERMIT2_ADDRESS } from "../constants/uniswap.js";
+import { GetCallsParams, GetCallsReturnType } from "./getCalls.js";
+
+export interface GetERC20TransferFromCallsParams extends GetCallsParams {
+    token: Address;
+    funder: Address;
+    minAmount: bigint;
+    targetAmount?: bigint;
+}
+
+export interface GetERC20TransferFromCallsReturnType extends GetCallsReturnType {
+    balance: bigint;
+}
+/**
+ * Get balance and return `IERC20.transferFrom` or `IAllowanceTransfer.transferFrom` call if below minAmount
+ * @dev Make sure to check `funder` balance & allowance is sufficient beforehand (if needed)
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ */
+export async function getERC20TransferFromCalls(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetERC20TransferFromCallsParams,
+): Promise<GetERC20TransferFromCallsReturnType> {
+    const { chainId, token, account, funder, minAmount } = params;
+    // Amount to approve if current allowance < minAmount
+    const targetAmount = params.targetAmount ?? minAmount;
+    invariant(targetAmount >= minAmount, "targetAmount must be >= minAmount");
+
+    const balance = await queryClient.fetchQuery(
+        readContractQueryOptions(wagmiConfig, {
+            chainId,
+            address: token,
+            abi: IERC20.abi,
+            functionName: "balanceOf",
+            args: [account],
+        }),
+    );
+
+    if (balance >= minAmount) {
+        return { balance, calls: [] };
+    }
+    // Transfer amount
+    const amount = targetAmount - balance;
+
+    // Queries
+    const allowancePromise = queryClient.fetchQuery(
+        readContractQueryOptions(wagmiConfig, {
+            chainId,
+            address: token,
+            abi: IERC20.abi,
+            functionName: "allowance",
+            args: [funder, account],
+        }),
+    );
+    const permit2AllowancePromise = queryClient.fetchQuery(
+        readContractQueryOptions(wagmiConfig, {
+            chainId,
+            address: PERMIT2_ADDRESS,
+            abi: IAllowanceTransfer.abi,
+            functionName: "allowance",
+            args: [funder, token, account],
+        }),
+    );
+
+    // Regular ERC20 transferFrom
+    const allowance = await allowancePromise;
+    if (allowance >= amount) {
+        const call = {
+            to: token,
+            data: encodeFunctionData({
+                abi: IERC20.abi,
+                functionName: "transferFrom",
+                args: [funder, account, amount],
+            }),
+            value: 0n,
+        };
+
+        return { balance, calls: [call] };
+    }
+
+    // Permit2 transferFrom
+    const permit2Allowance = await permit2AllowancePromise;
+    if (permit2Allowance[0] >= amount && permit2Allowance[1] > Date.now()) {
+        const call = {
+            to: PERMIT2_ADDRESS as Address,
+            data: encodeFunctionData({
+                abi: IAllowanceTransfer.abi,
+                functionName: "transferFrom",
+                args: [funder, account, amount, token],
+            }),
+            value: 0n,
+        };
+
+        return { balance, calls: [call] };
+    }
+
+    throw new Error("Not enough allowance for transferFrom");
+}

--- a/packages/veraswap-sdk/src/calls/getERC20TransferFromCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getERC20TransferFromCalls.ts
@@ -21,8 +21,9 @@ export interface GetERC20TransferFromCallsReturnType extends GetCallsReturnType 
     balance: bigint;
 }
 /**
- * Get balance and return `IERC20.transferFrom` or `IAllowanceTransfer.transferFrom` call if below minAmount
- * @dev Make sure to check `funder` balance & allowance is sufficient beforehand (if needed)
+ * Get balance and return `IERC20.transferFrom` or `IAllowanceTransfer.transferFrom` call if balance below `minAmount`
+ * @dev Assumes `token.balanceOf(funder) > minAmount`
+ * @dev Assumes `allowance(funder, account) > minAmount` (ERC20 or Permit2 allowance)
  * @param queryClient
  * @param wagmiConfig
  * @param params

--- a/packages/veraswap-sdk/src/calls/getExecutorRouterSetOwnersCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getExecutorRouterSetOwnersCalls.ts
@@ -17,7 +17,7 @@ export interface GetExecutorRouterSetOwnersReturnType extends GetCallsReturnType
 }
 
 /**
- * Call `ERC7579ExecutorRouter.setAccountOwners` if not at desired state
+ * Call `ERC7579ExecutorRouter.setAccountOwners(owners)` for owners in undesired state
  * @param queryClient
  * @param wagmiConfig
  * @param params

--- a/packages/veraswap-sdk/src/calls/getExecutorRouterSetOwnersCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getExecutorRouterSetOwnersCalls.ts
@@ -1,0 +1,58 @@
+import { Config } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+
+import { readContractQueryOptions } from "wagmi/query";
+import { Address, encodeFunctionData } from "viem";
+
+import { GetCallsParams, GetCallsReturnType } from "./getCalls.js";
+import { ERC7579ExecutorRouter } from "../artifacts/ERC7579ExecutorRouter.js";
+
+export interface GetExecutorRouterSetOwnersParams extends GetCallsParams {
+    router: Address;
+    owners: { domain: number; router: Address; owner: Address; enabled: boolean }[];
+}
+
+export interface GetExecutorRouterSetOwnersReturnType extends GetCallsReturnType {
+    isOwner: readonly boolean[];
+}
+
+/**
+ * Call `ERC7579ExecutorRouter.setAccountOwners` if not at desired state
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ */
+export async function getExecutorRouterSetOwnersCalls(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetExecutorRouterSetOwnersParams,
+): Promise<GetExecutorRouterSetOwnersReturnType> {
+    const { chainId, account, router, owners } = params;
+
+    const isOwner = await Promise.all(
+        owners.map((owner) =>
+            queryClient.fetchQuery(
+                readContractQueryOptions(wagmiConfig, {
+                    chainId,
+                    address: router,
+                    abi: ERC7579ExecutorRouter.abi,
+                    functionName: "owners",
+                    args: [account, owner.domain, owner.router, owner.owner],
+                }),
+            ),
+        ),
+    );
+    // Find all owner configs that do not match
+    const ownerUpdates = owners.filter((owner, idx) => owner.enabled != isOwner[idx]);
+
+    const call = {
+        to: router,
+        data: encodeFunctionData({
+            abi: ERC7579ExecutorRouter.abi,
+            functionName: "setAccountOwners",
+            args: [ownerUpdates],
+        }),
+        value: 0n,
+    };
+    return { isOwner, calls: [call] };
+}

--- a/packages/veraswap-sdk/src/calls/getOwnableExecutorAddOwnerCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getOwnableExecutorAddOwnerCalls.ts
@@ -18,7 +18,7 @@ export interface GetOwnableExecutorAddOwnerCallsReturnType extends GetCallsRetur
 }
 
 /**
- * Call `OwnableExecutor.addOwner` if `owner` is not yet added
+ * Call `OwnableExecutor.addOwner(owner)` if `owner` is not yet added
  * @param queryClient
  * @param wagmiConfig
  * @param params

--- a/packages/veraswap-sdk/src/calls/getOwnableExecutorAddOwnerCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getOwnableExecutorAddOwnerCalls.ts
@@ -1,0 +1,57 @@
+import { Config } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+
+import { readContractQueryOptions } from "wagmi/query";
+import { Address, encodeFunctionData } from "viem";
+
+import { OwnableSignatureExecutor } from "../artifacts/OwnableSignatureExecutor.js";
+
+import { GetCallsParams, GetCallsReturnType } from "./getCalls.js";
+
+export interface GetOwnableExecutorAddOwnerCallsParams extends GetCallsParams {
+    executor: Address;
+    owner: Address;
+}
+
+export interface GetOwnableExecutorAddOwnerCallsReturnType extends GetCallsReturnType {
+    owners: readonly Address[];
+}
+
+/**
+ * Call `OwnableExecutor.addOwner` if `owner` is not yet added
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ */
+export async function getOwnableExecutorAddOwnerCalls(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetOwnableExecutorAddOwnerCallsParams,
+): Promise<GetOwnableExecutorAddOwnerCallsReturnType> {
+    const { chainId, account, executor, owner } = params;
+
+    const owners = await queryClient.fetchQuery(
+        readContractQueryOptions(wagmiConfig, {
+            chainId,
+            address: executor,
+            abi: OwnableSignatureExecutor.abi,
+            functionName: "getOwners",
+            args: [account],
+        }),
+    );
+
+    if (owners.includes(owner)) {
+        return { owners, calls: [] };
+    }
+
+    const call = {
+        to: executor,
+        data: encodeFunctionData({
+            abi: OwnableSignatureExecutor.abi,
+            functionName: "addOwner",
+            args: [owner],
+        }),
+        value: 0n,
+    };
+    return { owners, calls: [call] };
+}

--- a/packages/veraswap-sdk/src/calls/getPermit2ApproveCalls.test.ts
+++ b/packages/veraswap-sdk/src/calls/getPermit2ApproveCalls.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test, beforeEach } from "vitest";
+import { getAnvilAccount } from "@veraswap/anvil-account";
+import { createConfig, http } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+
+import { opChainL1, opChainL1Client } from "../chains/supersim.js";
+
+import { localMockTokens } from "../constants/tokens.js";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { Account, Chain, createWalletClient, parseEther, Transport, WalletClient } from "viem";
+import { PERMIT2_ADDRESS } from "../constants/uniswap.js";
+import { IAllowanceTransfer } from "../artifacts/IAllowanceTransfer.js";
+import { getPermit2ApproveCalls } from "./getPermit2ApproveCalls.js";
+import { IERC20 } from "@owlprotocol/contracts-hyperlane";
+import { MockERC20 } from "../artifacts/MockERC20.js";
+
+describe("calls/getPermit2ApproveCall.test.ts", function () {
+    const config = createConfig({
+        chains: [opChainL1],
+        transports: {
+            [opChainL1.id]: http(),
+        },
+    });
+    const queryClient = new QueryClient();
+
+    let account: Account;
+    let accountClient: WalletClient<Transport, Chain, Account>;
+    let spender: Account;
+
+    const tokenA = localMockTokens[0];
+
+    beforeEach(async () => {
+        const anvilAccount = getAnvilAccount();
+        const anvilClient = createWalletClient({
+            account: anvilAccount,
+            chain: opChainL1Client.chain,
+            transport: http(),
+        });
+
+        account = privateKeyToAccount(generatePrivateKey());
+        accountClient = createWalletClient({
+            account,
+            chain: opChainL1Client.chain,
+            transport: http(),
+        });
+        spender = privateKeyToAccount(generatePrivateKey());
+        // Fund account with Ether
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.sendTransaction({
+                to: account.address,
+                value: parseEther("1"),
+            }),
+        });
+        // Fund account with Token A
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.writeContract({
+                address: tokenA.address,
+                abi: MockERC20.abi,
+                functionName: "mint",
+                args: [account.address, parseEther("100")],
+            }),
+        });
+    });
+
+    test("getPermit2ApproveCalls - PERMIT2 NOT approved", async () => {
+        // Approve from account to spender
+        const approvePermit2Call = await getPermit2ApproveCalls(queryClient, config, {
+            chainId: opChainL1.id,
+            token: tokenA.address,
+            account: account.address,
+            spender: spender.address,
+            minAmount: 1n,
+            approveExpiration: Date.now() + 24 * 60 * 60,
+        });
+        expect(approvePermit2Call.allowance).toBe(0n);
+        expect(approvePermit2Call.calls.length).toBe(2);
+
+        // Approve PERMIT2 `IERC20.approve(PERMIT2_ADDRESS, 1)`
+        expect(approvePermit2Call.calls[0]).toBeDefined();
+        expect(approvePermit2Call.calls[0].to).toBe(tokenA.address);
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await accountClient.sendTransaction(approvePermit2Call.calls[0]),
+        });
+
+        // Send from account `IAllowance.approve(token, spender, approveAmount, approveExpiration)`
+        expect(approvePermit2Call.calls[1]).toBeDefined();
+        expect(approvePermit2Call.calls[1].to).toBe(PERMIT2_ADDRESS);
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await accountClient.sendTransaction(approvePermit2Call.calls[1]),
+        });
+
+        // Check allowance of spender
+        const allowance = await opChainL1Client.readContract({
+            address: PERMIT2_ADDRESS,
+            abi: IAllowanceTransfer.abi,
+            functionName: "allowance",
+            args: [account.address, tokenA.address, spender.address],
+        });
+        expect(allowance[0]).toBe(1n);
+    });
+
+    test("getPermit2ApproveCalls - PERMIT2 Already approved", async () => {
+        // Approve PERMIT2 with MAX_UINT256
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await accountClient.writeContract({
+                address: tokenA.address,
+                abi: IERC20.abi,
+                functionName: "approve",
+                args: [PERMIT2_ADDRESS, 2n ** 256n - 1n],
+            }),
+        });
+
+        // Approve from account to spender
+        const approvePermit2Call = await getPermit2ApproveCalls(queryClient, config, {
+            chainId: opChainL1.id,
+            token: tokenA.address,
+            account: account.address,
+            spender: spender.address,
+            minAmount: 1n,
+            approveExpiration: Date.now() + 24 * 60 * 60,
+        });
+        expect(approvePermit2Call.allowance).toBe(0n);
+        expect(approvePermit2Call.calls.length).toBe(1);
+
+        // Send from account `IAllowance.approve(token, spender, approveAmount, approveExpiration)`
+        expect(approvePermit2Call.calls[0]).toBeDefined();
+        expect(approvePermit2Call.calls[0].to).toBe(PERMIT2_ADDRESS);
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await accountClient.sendTransaction(approvePermit2Call.calls[0]),
+        });
+
+        // Check allowance of spender
+        const allowance = await opChainL1Client.readContract({
+            address: PERMIT2_ADDRESS,
+            abi: IAllowanceTransfer.abi,
+            functionName: "allowance",
+            args: [account.address, tokenA.address, spender.address],
+        });
+        expect(allowance[0]).toBe(1n);
+    });
+});

--- a/packages/veraswap-sdk/src/calls/getPermit2ApproveCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getPermit2ApproveCalls.ts
@@ -25,9 +25,9 @@ export interface GetPermit2ApproveCallsReturnType extends GetCallsReturnType {
 }
 
 /**
- * Get spender Permit2 allowance and return `IAllowance.approve` call if below minAmount
- * @dev Make sure to check `owner` balance is sufficient beforehand (if needed)
- * @dev Make sure to check the Permit2 contract is approved first
+ * Get spender Permit2 allowance and return `IAllowance.approve(token, spender, approveAmount, approveExpiration)` call if allowance below `minAmount` or expired
+ * @dev Assumes `token.balanceOf(account) > minAmount`
+ * @dev Assumes `token.allowance(account, PERMIT2) > minAmount`
  * @param queryClient
  * @param wagmiConfig
  * @param params

--- a/packages/veraswap-sdk/src/calls/getPermit2ApproveCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getPermit2ApproveCalls.ts
@@ -1,0 +1,82 @@
+import { Config } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+
+import { readContractQueryOptions } from "wagmi/query";
+import { Address, encodeFunctionData } from "viem";
+import invariant from "tiny-invariant";
+
+import { IAllowanceTransfer } from "../artifacts/IAllowanceTransfer.js";
+import { PERMIT2_ADDRESS } from "../constants/uniswap.js";
+
+import { GetCallsParams, GetCallsReturnType } from "./getCalls.js";
+
+export interface GetPermit2ApproveCallsParams extends GetCallsParams {
+    token: Address;
+    spender: Address;
+    minAmount: bigint;
+    approveAmount?: bigint;
+    minExpiration?: number;
+    approveExpiration: number;
+}
+
+export interface GetPermit2ApproveCallsReturnType extends GetCallsReturnType {
+    allowance: bigint;
+    expiration: number;
+}
+
+/**
+ * Get spender Permit2 allowance and return `IAllowance.approve` call if below minAmount
+ * @dev Make sure to check `owner` balance is sufficient beforehand (if needed)
+ * @dev Make sure to check the Permit2 contract is approved first
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ */
+export async function getPermit2ApproveCalls(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetPermit2ApproveCallsParams,
+): Promise<GetPermit2ApproveCallsReturnType> {
+    const { chainId, token, account, spender, minAmount, approveExpiration } = params;
+    // Amount to approve if current allowance < minAmount
+    const approveAmount = params.approveAmount ?? minAmount;
+    invariant(approveAmount >= minAmount, "approveAmount must be >= minAmount");
+
+    // Expiration timestamp for Permit2 approval
+    invariant(
+        params.minExpiration == undefined || params.minExpiration >= Date.now(),
+        "minExpiration must be undefined || >= Date.now()",
+    );
+    invariant(
+        approveExpiration >= (params.minExpiration ?? Date.now()),
+        "approveExpiration must be >= (minExpiration ?? Date.now())",
+    );
+
+    const [allowance, expiration, _] = await queryClient.fetchQuery(
+        readContractQueryOptions(wagmiConfig, {
+            chainId,
+            address: PERMIT2_ADDRESS,
+            abi: IAllowanceTransfer.abi,
+            functionName: "allowance",
+            args: [account, token, spender],
+        }),
+    );
+
+    // Default minExpiration to Date.now()
+    const minExpiration = params.minExpiration ?? Date.now();
+    if (allowance >= minAmount && expiration > minExpiration) {
+        return { allowance, expiration, calls: [] };
+    }
+
+    const call = {
+        to: PERMIT2_ADDRESS as Address,
+        data: encodeFunctionData({
+            abi: IAllowanceTransfer.abi,
+            functionName: "approve",
+            args: [token, spender, approveAmount, approveExpiration],
+        }),
+        value: 0n,
+    };
+
+    return { allowance, expiration, calls: [call] };
+}

--- a/packages/veraswap-sdk/src/calls/getPermit2PermitCalls.test.ts
+++ b/packages/veraswap-sdk/src/calls/getPermit2PermitCalls.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test, beforeEach, beforeAll } from "vitest";
+import { getAnvilAccount } from "@veraswap/anvil-account";
+import { connect, createConfig, http, mock } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+
+import { opChainL1, opChainL1Client } from "../chains/supersim.js";
+
+import { localMockTokens } from "../constants/tokens.js";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { Account, createWalletClient } from "viem";
+import { PERMIT2_ADDRESS } from "../constants/uniswap.js";
+import { IAllowanceTransfer } from "../artifacts/IAllowanceTransfer.js";
+import { IERC20 } from "@owlprotocol/contracts-hyperlane";
+import { getPermit2PermitCalls } from "./getPermit2PermitCalls.js";
+
+describe("calls/getPermit2PermitCall.test.ts", function () {
+    const anvilAccount = getAnvilAccount();
+    const anvilClient = createWalletClient({
+        account: anvilAccount,
+        chain: opChainL1Client.chain,
+        transport: http(),
+    });
+
+    // Mock connector to use wagmi signing
+    const mockConnector = mock({
+        accounts: [
+            //only works because anvil will allow RPC based signing (connector does not use in-memory pkey)
+            getAnvilAccount(1).address,
+        ],
+    });
+    const config = createConfig({
+        chains: [opChainL1],
+        transports: {
+            [opChainL1.id]: http(),
+        },
+        connectors: [mockConnector],
+    });
+    const queryClient = new QueryClient();
+
+    // Have to use anvil account for the mock connector
+    const account = getAnvilAccount(1);
+    const accountClient = createWalletClient({
+        account,
+        chain: opChainL1Client.chain,
+        transport: http(),
+    });
+    let spender: Account;
+
+    const tokenA = localMockTokens[0];
+
+    beforeAll(async () => {
+        await connect(config, {
+            chainId: opChainL1.id,
+            connector: mockConnector,
+        });
+    });
+
+    beforeEach(() => {
+        spender = privateKeyToAccount(generatePrivateKey());
+    });
+
+    test("getPermit2PermitCall - PERMIT2 Already approved", async () => {
+        // Approve PERMIT2 with MAX_UINT256
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await accountClient.writeContract({
+                address: tokenA.address,
+                abi: IERC20.abi,
+                functionName: "approve",
+                args: [PERMIT2_ADDRESS, 2n ** 256n - 1n],
+            }),
+        });
+
+        // Approve from account to spender
+        const approvePermit2Call = await getPermit2PermitCalls(queryClient, config, {
+            chainId: opChainL1.id,
+            token: tokenA.address,
+            account: account.address,
+            spender: spender.address,
+            minAmount: 1n,
+            approveExpiration: Date.now() + 24 * 60 * 60,
+        });
+        expect(approvePermit2Call.allowance).toBe(0n);
+        expect(approvePermit2Call.calls.length).toBe(1);
+
+        // Send from account `IAllowance.approve(token, spender, approveAmount, approveExpiration)`
+        expect(approvePermit2Call.calls[0]).toBeDefined();
+        expect(approvePermit2Call.calls[0].to).toBe(PERMIT2_ADDRESS);
+        await opChainL1Client.waitForTransactionReceipt({
+            // Transaction sent from anvil account but works because of signature
+            hash: await anvilClient.sendTransaction(approvePermit2Call.calls[0]),
+        });
+
+        // Check allowance of spender
+        const allowance = await opChainL1Client.readContract({
+            address: PERMIT2_ADDRESS,
+            abi: IAllowanceTransfer.abi,
+            functionName: "allowance",
+            args: [account.address, tokenA.address, spender.address],
+        });
+        expect(allowance[0]).toBe(1n);
+    });
+});

--- a/packages/veraswap-sdk/src/calls/getPermit2PermitCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getPermit2PermitCalls.ts
@@ -85,7 +85,6 @@ export async function getPermit2PermitCalls(
         sigDeadline: BigInt(Math.floor(Date.now() / 1000) + 24 * 60 * 60),
     };
     const permitData = AllowanceTransfer.getPermitData(permitSingle, PERMIT2_ADDRESS, chainId);
-    console.debug(permitData);
     const signature = await signTypedData(wagmiConfig, {
         account,
         domain: permitData.domain as TypedDataDomain,

--- a/packages/veraswap-sdk/src/calls/getPermit2PermitCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getPermit2PermitCalls.ts
@@ -1,0 +1,108 @@
+import { Config, signTypedData } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+import { readContractQueryOptions } from "wagmi/query";
+import { Address, bytesToNumber, encodeFunctionData, TypedDataDomain } from "viem";
+import invariant from "tiny-invariant";
+import { AllowanceTransfer } from "@uniswap/permit2-sdk";
+
+import {
+    IAllowanceTransfer,
+    permit_address___address_uint160_uint48_uint48__address_uint256__bytes,
+} from "../artifacts/IAllowanceTransfer.js";
+import { PERMIT2_ADDRESS } from "../constants/uniswap.js";
+
+import { GetCallsParams, GetCallsReturnType } from "./getCalls.js";
+import { PermitSingle } from "../types/AllowanceTransfer.js";
+
+export interface GetPermit2PermitCallsParams extends GetCallsParams {
+    token: Address;
+    spender: Address;
+    minAmount: bigint;
+    approveAmount?: bigint;
+    minExpiration?: number;
+    approveExpiration: number;
+}
+
+export interface GetPermit2PermitCallsReturnType extends GetCallsReturnType {
+    allowance: bigint;
+    expiration: number;
+}
+
+/**
+ * Get spender Permit2 allowance and return `IAllowance.permit(account, permitDetails, signature)` call if allowance below `minAmount` or expired
+ * @devs **Requires** `signTypedMessage` call from `account`
+ * @dev Assumes `token.balanceOf(account) > minAmount`
+ * @dev Assumes `token.allowance(account, PERMIT2) > minAmount`
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ */
+export async function getPermit2PermitCalls(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetPermit2PermitCallsParams,
+): Promise<GetPermit2PermitCallsReturnType> {
+    const { chainId, token, account, spender, minAmount, approveExpiration } = params;
+    // Amount to approve if current allowance < minAmount
+    const approveAmount = params.approveAmount ?? minAmount;
+    invariant(approveAmount >= minAmount, "approveAmount must be >= minAmount");
+
+    // Expiration timestamp for Permit2 approval
+    invariant(
+        params.minExpiration == undefined || params.minExpiration >= Date.now(),
+        "minExpiration must be undefined || >= Date.now()",
+    );
+    invariant(
+        approveExpiration >= (params.minExpiration ?? Date.now()),
+        "approveExpiration must be >= (minExpiration ?? Date.now())",
+    );
+
+    const [allowance, expiration, _] = await queryClient.fetchQuery(
+        readContractQueryOptions(wagmiConfig, {
+            chainId,
+            address: PERMIT2_ADDRESS,
+            abi: IAllowanceTransfer.abi,
+            functionName: "allowance",
+            args: [account, token, spender],
+        }),
+    );
+
+    // Default minExpiration to Date.now()
+    const minExpiration = params.minExpiration ?? Date.now();
+    if (allowance >= minAmount && expiration > minExpiration) {
+        return { allowance, expiration, calls: [] };
+    }
+
+    //uint48 nonce
+    const nonce = bytesToNumber(crypto.getRandomValues(new Uint8Array(6)));
+    const permitSingle: PermitSingle = {
+        details: {
+            token,
+            amount: approveAmount,
+            expiration: Math.floor(Date.now() / 1000) + 24 * 60 * 60,
+            nonce,
+        },
+        spender,
+        sigDeadline: BigInt(Math.floor(Date.now() / 1000) + 24 * 60 * 60),
+    };
+    const permitData = AllowanceTransfer.getPermitData(permitSingle, PERMIT2_ADDRESS, chainId);
+    const signature = await signTypedData(wagmiConfig, {
+        account,
+        domain: permitData.domain as TypedDataDomain,
+        types: permitData.types,
+        primaryType: "PermitTransferFrom",
+        message: permitData.values as unknown as Record<string, unknown>,
+    });
+
+    const call = {
+        to: PERMIT2_ADDRESS as Address,
+        data: encodeFunctionData({
+            abi: [permit_address___address_uint160_uint48_uint48__address_uint256__bytes],
+            functionName: "permit",
+            args: [token, permitSingle, signature],
+        }),
+        value: 0n,
+    };
+
+    return { allowance, expiration, calls: [call] };
+}

--- a/packages/veraswap-sdk/src/calls/getTransferRemoteCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getTransferRemoteCalls.ts
@@ -25,7 +25,7 @@ export interface GetTransferRemoteCallsParams extends GetCallsParams {
 
 /**
  * Get call to fund & set appprovals for `TokenRouter.transferRemote` call
- * @dev Make sure to check `owner` balance is sufficient beforehand (if needed)
+ * @dev Assumes `token.balanceOf(account) > amount`
  * @param queryClient
  * @param wagmiConfig
  * @param params

--- a/packages/veraswap-sdk/src/calls/getTransferRemoteCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getTransferRemoteCalls.ts
@@ -1,0 +1,157 @@
+import { Config } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+
+import { readContractQueryOptions } from "wagmi/query";
+import { Address, Hex } from "viem";
+
+import { CallArgs } from "../smartaccount/ExecLib.js";
+import { getTransferRemoteCall } from "../swap/getTransferRemoteCall.js";
+import { HypERC20Collateral } from "../artifacts/HypERC20Collateral.js";
+import { getERC20TransferFromCalls } from "./getERC20TransferFromCalls.js";
+import { getERC20ApproveCalls } from "./getERC20ApproveCalls.js";
+
+import { GetCallsParams, GetCallsReturnType } from "./getCalls.js";
+
+export interface GetTransferRemoteCallsParams extends GetCallsParams {
+    funder: Address;
+    tokenStandard: "HypERC20" | "HypERC20Collateral";
+    token: Address;
+    destination: number;
+    recipient: Address;
+    amount: bigint;
+    hookMetadata?: Hex;
+    hook?: Address;
+}
+
+/**
+ * Get call to fund & set appprovals for `TokenRouter.transferRemote` call
+ * @dev Make sure to check `owner` balance is sufficient beforehand (if needed)
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ */
+export async function getTransferRemoteCalls(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetTransferRemoteCallsParams,
+): Promise<GetCallsReturnType> {
+    const { chainId, account, funder, tokenStandard, token, destination, recipient, amount, hookMetadata, hook } =
+        params;
+    const calls: CallArgs[] = [];
+
+    let wrappedToken = token;
+    if (tokenStandard === "HypERC20Collateral") {
+        // HypERC20Collateral requires approval for wrapped token
+        wrappedToken = await queryClient.fetchQuery(
+            readContractQueryOptions(wagmiConfig, {
+                chainId,
+                address: token,
+                abi: HypERC20Collateral.abi,
+                functionName: "wrappedToken",
+                args: [],
+            }),
+        );
+    }
+
+    // Fund owner if necessary
+    const transferFromCall = await getERC20TransferFromCalls(queryClient, wagmiConfig, {
+        chainId,
+        token: wrappedToken,
+        account,
+        funder,
+        minAmount: amount,
+    });
+    calls.push(...transferFromCall.calls);
+
+    // Approve HypERC20Collateral and call `transferRemote`
+    const transferRemoteCall = await getTransferRemoteWithApprovalCalls(queryClient, wagmiConfig, {
+        chainId,
+        account,
+        tokenStandard,
+        token,
+        destination,
+        recipient,
+        amount,
+        hookMetadata,
+        hook,
+    });
+    calls.push(...transferRemoteCall.calls);
+
+    return { calls };
+}
+
+export interface GetTransferRemoteWithApprovalCallsParams extends GetCallsParams {
+    tokenStandard: "HypERC20" | "HypERC20Collateral";
+    token: Address;
+    destination: number;
+    recipient: Address;
+    amount: bigint;
+    hookMetadata?: Hex;
+    hook?: Address;
+}
+
+/**
+ * Get `IERC20.approve` call (if HypERC20Collateral) and `TokenRouter.transferRemote` call
+ * @dev Make sure to check `owner` balance is sufficient beforehand (if needed)
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ */
+export async function getTransferRemoteWithApprovalCalls(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetTransferRemoteWithApprovalCallsParams,
+): Promise<{ calls: CallArgs[] }> {
+    const { chainId, account, tokenStandard, token, destination, recipient, amount, hookMetadata, hook } = params;
+
+    const calls: CallArgs[] = [];
+
+    // Start fetching gas payment quote in background
+    const gasPaymentPromise = queryClient.fetchQuery(
+        readContractQueryOptions(wagmiConfig, {
+            chainId,
+            address: token,
+            abi: HypERC20Collateral.abi,
+            functionName: "quoteGasPayment",
+            args: [destination],
+        }),
+    );
+
+    if (tokenStandard === "HypERC20Collateral") {
+        // HypERC20Collateral requires approval for wrapped token
+        const wrappedToken = await queryClient.fetchQuery(
+            readContractQueryOptions(wagmiConfig, {
+                chainId,
+                address: token,
+                abi: HypERC20Collateral.abi,
+                functionName: "wrappedToken",
+                args: [],
+            }),
+        );
+        const approvalCall = await getERC20ApproveCalls(queryClient, wagmiConfig, {
+            chainId,
+            token: wrappedToken,
+            account,
+            spender: token,
+            minAmount: amount,
+        });
+        // Add required approval
+        calls.push(...approvalCall.calls);
+    }
+
+    const gasPayment = await gasPaymentPromise;
+
+    // Encode transfer remote call
+    const transferRemoteCall = getTransferRemoteCall({
+        address: token,
+        destination,
+        recipient,
+        amount,
+        hook,
+        hookMetadata,
+        bridgePayment: gasPayment,
+    });
+    calls.push(transferRemoteCall);
+
+    return { calls };
+}

--- a/packages/veraswap-sdk/src/calls/getTransferRemoteCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getTransferRemoteCalls.ts
@@ -53,7 +53,7 @@ export async function getTransferRemoteCalls(
         );
     }
 
-    // Fund owner if necessary
+    // Fund account if necessary
     const transferFromCall = await getERC20TransferFromCalls(queryClient, wagmiConfig, {
         chainId,
         token: wrappedToken,

--- a/packages/veraswap-sdk/src/calls/index.test.ts
+++ b/packages/veraswap-sdk/src/calls/index.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test, beforeEach } from "vitest";
+import { getAnvilAccount } from "@veraswap/anvil-account";
+import { createConfig, getBalance, http } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+
+import { opChainL1, opChainL1Client } from "../chains/supersim.js";
+import { getBalanceQueryOptions } from "wagmi/query";
+import { getTransferRemoteCalls, getTransferRemoteWithApprovalCalls } from "./getTransferRemoteCalls.js";
+import { LOCAL_TOKENS, localMockTokens } from "../constants/tokens.js";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { Account, Chain, createWalletClient, parseEther, Transport, WalletClient } from "viem";
+import { IERC20 } from "../artifacts/IERC20.js";
+import { PERMIT2_ADDRESS } from "../constants/uniswap.js";
+import { IAllowanceTransfer } from "../artifacts/IAllowanceTransfer.js";
+import { getERC20ApproveCalls } from "./getERC20ApproveCalls.js";
+import { getERC20TransferFromCalls } from "./getERC20TransferFromCalls.js";
+import { getPermit2ApproveCalls } from "./getPermit2ApproveCalls.js";
+
+describe("calls/index.test.ts", function () {
+    const anvilAccount = getAnvilAccount();
+    const anvilClient = createWalletClient({
+        account: anvilAccount,
+        chain: opChainL1Client.chain,
+        transport: http(),
+    });
+
+    const config = createConfig({
+        chains: [opChainL1],
+        transports: {
+            [opChainL1.id]: http(),
+        },
+    });
+    const queryClient = new QueryClient();
+
+    let account: Account;
+    let accountClient: WalletClient<Transport, Chain, Account>;
+
+    const tokenA = localMockTokens[0];
+    const tokenAHypERC20Collateral = LOCAL_TOKENS[0];
+
+    beforeEach(async () => {
+        account = privateKeyToAccount(generatePrivateKey());
+        accountClient = createWalletClient({
+            account,
+            chain: opChainL1Client.chain,
+            transport: http(),
+        });
+        // Fund account
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.sendTransaction({
+                to: account.address,
+                value: parseEther("1"),
+            }),
+        });
+    });
+
+    test("getBalance", async () => {
+        // Example test fetching balance in 3 ways
+
+        // viem
+        const viemResult = await opChainL1Client.getBalance({
+            address: anvilAccount.address,
+        });
+        // wagmi/core: calls viem via global config, accepts chainId as parameter
+        const wagmiResult = await getBalance(config, { chainId: opChainL1.id, address: anvilAccount.address });
+        expect(wagmiResult.value).toBe(viemResult);
+        // tanstack/query: call wagmi/core logic via queryOptions supporting custom caching logic
+        const queryResult = await queryClient.fetchQuery(
+            getBalanceQueryOptions(config, { chainId: opChainL1.id, address: anvilAccount.address }),
+        );
+        expect(queryResult.value).toBe(viemResult);
+    });
+
+    test("getTransferRemoteCalls", async () => {
+        const preCollateralBalance = await opChainL1Client.readContract({
+            address: tokenA.address,
+            abi: IERC20.abi,
+            functionName: "balanceOf",
+            args: [tokenAHypERC20Collateral.address],
+        });
+
+        // Approve account as spender
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.writeContract({
+                address: tokenA.address,
+                abi: IERC20.abi,
+                functionName: "approve",
+                args: [account.address, 1n],
+            }),
+        });
+
+        // Approve from anvilAccount to account
+        const transferRemoteCalls = await getTransferRemoteCalls(queryClient, config, {
+            chainId: opChainL1.id,
+            token: tokenAHypERC20Collateral.address,
+            tokenStandard: "HypERC20Collateral",
+            account: account.address,
+            funder: anvilAccount.address,
+            destination: 901,
+            recipient: account.address,
+            amount: 1n,
+        });
+        expect(transferRemoteCalls.calls.length).toBe(3);
+
+        // ERC20.transferFrom(anvilAccount, account, 1)
+        expect(transferRemoteCalls.calls[0].to).toBe(tokenA.address);
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await accountClient.sendTransaction(transferRemoteCalls.calls[0]),
+        });
+        const balanceAccount = await opChainL1Client.readContract({
+            address: tokenA.address,
+            abi: IERC20.abi,
+            functionName: "balanceOf",
+            args: [account.address],
+        });
+        expect(balanceAccount).toBe(1n);
+
+        // ERC20.approve(HypERC20Collateral, 1)
+        expect(transferRemoteCalls.calls[1].to).toBe(tokenA.address);
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await accountClient.sendTransaction(transferRemoteCalls.calls[1]),
+        });
+        const allowance = await opChainL1Client.readContract({
+            address: tokenA.address,
+            abi: IERC20.abi,
+            functionName: "allowance",
+            args: [account.address, tokenAHypERC20Collateral.address],
+        });
+        expect(allowance).toBe(1n);
+
+        // HypERC20Collateral.transferRemote()
+        expect(transferRemoteCalls.calls[2].to).toBe(tokenAHypERC20Collateral.address);
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await accountClient.sendTransaction(transferRemoteCalls.calls[2]),
+        });
+        const postCollateralBalance = await opChainL1Client.readContract({
+            address: tokenA.address,
+            abi: IERC20.abi,
+            functionName: "balanceOf",
+            args: [tokenAHypERC20Collateral.address],
+        });
+        expect(postCollateralBalance - preCollateralBalance).toBe(1n);
+    });
+
+    test("getTransferRemoteWithApprovalCalls", async () => {
+        const preCollateralBalance = await opChainL1Client.readContract({
+            address: tokenA.address,
+            abi: IERC20.abi,
+            functionName: "balanceOf",
+            args: [tokenAHypERC20Collateral.address],
+        });
+
+        // Approve from anvilAccount to account
+        const transferRemoteCalls = await getTransferRemoteWithApprovalCalls(queryClient, config, {
+            chainId: opChainL1.id,
+            token: tokenAHypERC20Collateral.address,
+            tokenStandard: "HypERC20Collateral",
+            account: anvilAccount.address,
+            destination: 901,
+            recipient: account.address,
+            amount: 1n,
+        });
+
+        expect(transferRemoteCalls.calls.length).toBe(2);
+        // ERC20.approve(HypERC20Collateral, 1)
+        expect(transferRemoteCalls.calls[0].to).toBe(tokenA.address);
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.sendTransaction(transferRemoteCalls.calls[0]),
+        });
+        const allowance = await opChainL1Client.readContract({
+            address: tokenA.address,
+            abi: IERC20.abi,
+            functionName: "allowance",
+            args: [anvilAccount.address, tokenAHypERC20Collateral.address],
+        });
+        expect(allowance).toBe(1n);
+
+        // HypERC20Collateral.transferRemote()
+        expect(transferRemoteCalls.calls[1].to).toBe(tokenAHypERC20Collateral.address);
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.sendTransaction(transferRemoteCalls.calls[1]),
+        });
+        const postCollateralBalance = await opChainL1Client.readContract({
+            address: tokenA.address,
+            abi: IERC20.abi,
+            functionName: "balanceOf",
+            args: [tokenAHypERC20Collateral.address],
+        });
+        expect(postCollateralBalance - preCollateralBalance).toBe(1n);
+    });
+
+    test("getPermit2ApprovalCall", async () => {
+        // Approve from anvilAccount to account
+        const approvePermit2Call = await getPermit2ApproveCalls(queryClient, config, {
+            chainId: opChainL1.id,
+            token: tokenA.address,
+            account: anvilAccount.address,
+            spender: account.address,
+            minAmount: 1n,
+            approveExpiration: Date.now() + 24 * 60 * 60,
+        });
+
+        expect(approvePermit2Call.allowance).toBe(0n);
+        expect(approvePermit2Call.calls[0]).toBeDefined();
+        // Transfer using regular approval
+        expect(approvePermit2Call.calls[0].to).toBe(PERMIT2_ADDRESS);
+
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.sendTransaction(approvePermit2Call.calls[0]),
+        });
+
+        // Check balance of account
+        const allowance = await opChainL1Client.readContract({
+            address: PERMIT2_ADDRESS,
+            abi: IAllowanceTransfer.abi,
+            functionName: "allowance",
+            args: [anvilAccount.address, tokenA.address, account.address],
+        });
+        expect(allowance[0]).toBe(1n);
+    });
+
+    test("getApprovalCall", async () => {
+        // Approve from anvilAccount to account
+        const approveCall = await getERC20ApproveCalls(queryClient, config, {
+            chainId: opChainL1.id,
+            token: tokenA.address,
+            account: anvilAccount.address,
+            spender: account.address,
+            minAmount: 1n,
+        });
+
+        expect(approveCall.allowance).toBe(0n);
+        expect(approveCall.calls[0]).toBeDefined();
+        // Transfer using regular approval
+        expect(approveCall.calls[0].to).toBe(tokenA.address);
+
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.sendTransaction(approveCall.calls[0]),
+        });
+
+        // Check balance of account
+        const allowance = await opChainL1Client.readContract({
+            address: tokenA.address,
+            abi: IERC20.abi,
+            functionName: "allowance",
+            args: [anvilAccount.address, account.address],
+        });
+        expect(allowance).toBe(1n);
+    });
+
+    test("getTransferFromCall", async () => {
+        // Approve account as spender
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await anvilClient.writeContract({
+                address: tokenA.address,
+                abi: IERC20.abi,
+                functionName: "approve",
+                args: [account.address, 1n],
+            }),
+        });
+
+        // Transfer from anvilAccount to account
+        const transferFromCall = await getERC20TransferFromCalls(queryClient, config, {
+            chainId: opChainL1.id,
+            token: tokenA.address,
+            account: account.address,
+            funder: anvilAccount.address,
+            minAmount: 1n,
+        });
+
+        expect(transferFromCall.balance).toBe(0n);
+        expect(transferFromCall.calls[0]).toBeDefined();
+        // Transfer using regular approval
+        expect(transferFromCall.calls[0].to).toBe(tokenA.address);
+
+        await opChainL1Client.waitForTransactionReceipt({
+            hash: await accountClient.sendTransaction(transferFromCall.calls[0]),
+        });
+
+        // Check balance of account
+        const balance = await opChainL1Client.readContract({
+            address: tokenA.address,
+            abi: IERC20.abi,
+            functionName: "balanceOf",
+            args: [account.address],
+        });
+        expect(balance).toBe(1n);
+    });
+});

--- a/packages/veraswap-sdk/src/calls/index.ts
+++ b/packages/veraswap-sdk/src/calls/index.ts
@@ -1,0 +1,5 @@
+export * from "./getBridgeSwapCalls.js";
+export * from "./getERC20ApproveCalls.js";
+export * from "./getERC20TransferFromCalls.js";
+export * from "./getPermit2ApproveCalls.js";
+export * from "./getTransferRemoteCalls.js";

--- a/packages/veraswap-sdk/src/calls/index.ts
+++ b/packages/veraswap-sdk/src/calls/index.ts
@@ -4,4 +4,5 @@ export * from "./getERC20TransferFromCalls.js";
 export * from "./getExecutorRouterSetOwnersCalls.js";
 export * from "./getOwnableExecutorAddOwnerCalls.js";
 export * from "./getPermit2ApproveCalls.js";
+export * from "./getPermit2PermitCalls.js";
 export * from "./getTransferRemoteCalls.js";

--- a/packages/veraswap-sdk/src/calls/index.ts
+++ b/packages/veraswap-sdk/src/calls/index.ts
@@ -1,5 +1,7 @@
 export * from "./getBridgeSwapCalls.js";
 export * from "./getERC20ApproveCalls.js";
 export * from "./getERC20TransferFromCalls.js";
+export * from "./getExecutorRouterSetOwnersCalls.js";
+export * from "./getOwnableExecutorAddOwnerCalls.js";
 export * from "./getPermit2ApproveCalls.js";
 export * from "./getTransferRemoteCalls.js";

--- a/packages/veraswap-sdk/src/constants/tokens.ts
+++ b/packages/veraswap-sdk/src/constants/tokens.ts
@@ -76,7 +76,7 @@ export function createMockERC20WarpRoute({
     return tokens as [HypERC20CollateralToken, ...HypERC20Token[]];
 }
 
-const localMockTokens: TokenBase<"MockERC20">[] = [
+export const localMockTokens: TokenBase<"MockERC20">[] = [
     {
         standard: "MockERC20",
         chainId: opChainL1.id,

--- a/packages/veraswap-sdk/src/swap/getTransferRemoteCall.ts
+++ b/packages/veraswap-sdk/src/swap/getTransferRemoteCall.ts
@@ -1,6 +1,16 @@
 import { encodeFunctionData, Address, Hex, padHex, zeroAddress } from "viem";
 import { HypERC20 } from "../artifacts/HypERC20.js";
 
+export interface GetTransferRemoteCallParams {
+    address: Address;
+    destination: number;
+    recipient: Address;
+    amount: bigint;
+    hookMetadata?: Hex;
+    hook?: Address;
+    bridgePayment: bigint;
+}
+
 export function getTransferRemoteCall({
     address,
     destination,
@@ -9,15 +19,7 @@ export function getTransferRemoteCall({
     hookMetadata,
     hook,
     bridgePayment,
-}: {
-    address: Address;
-    destination: number;
-    recipient: Address;
-    amount: bigint;
-    hookMetadata?: Hex;
-    hook?: Address;
-    bridgePayment: bigint;
-}): { to: Address; data: Hex; value: bigint } {
+}: GetTransferRemoteCallParams): { to: Address; data: Hex; value: bigint } {
     let data: Hex;
     if (!hook && !hookMetadata) {
         // Slightly more gas efficient (smaller data)

--- a/packages/veraswap-sdk/src/types/AllowanceTransfer.ts
+++ b/packages/veraswap-sdk/src/types/AllowanceTransfer.ts
@@ -1,0 +1,28 @@
+import { Address, TypedDataDomain, TypedData } from "viem";
+
+export interface PermitDetails {
+    token: Address;
+    amount: bigint;
+    expiration: number;
+    nonce: number;
+}
+export interface PermitSingle {
+    details: PermitDetails;
+    spender: Address;
+    sigDeadline: bigint;
+}
+export interface PermitBatch {
+    details: PermitDetails[];
+    spender: Address;
+    sigDeadline: bigint;
+}
+export interface PermitSingleData {
+    domain: TypedDataDomain;
+    types: TypedData;
+    values: PermitSingle;
+}
+export interface PermitBatchData {
+    domain: TypedDataDomain;
+    types: TypedData;
+    values: PermitBatch;
+}

--- a/packages/veraswap-sdk/src/types/index.ts
+++ b/packages/veraswap-sdk/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./AllowanceTransfer.js";
 export * from "./PermitTransferFromData.js";
 export * from "./PoolKey.js";
 export * from "./HyperlaneRegistry.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,6 +423,9 @@ importers:
       '@uniswap/v4-sdk':
         specifier: ^1.21.2
         version: 1.21.2(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@20.17.24)(typescript@5.8.2))(typescript@5.8.2)(utf-8-validate@5.0.10))
+      '@wagmi/connectors':
+        specifier: ^5.7.12
+        version: 5.7.12(@types/react@18.3.18)(@wagmi/core@2.16.7(@tanstack/query-core@5.24.8)(@types/react@18.3.18)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.21.19(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
       '@wagmi/core':
         specifier: ^2.9.10
         version: 2.16.7(@tanstack/query-core@5.24.8)(@types/react@18.3.18)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.21.19(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4))
@@ -2496,6 +2499,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
+    deprecated: 'The package is now available as "qr": npm install qr'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4705,6 +4709,16 @@ packages:
       typescript:
         optional: true
 
+  '@wagmi/connectors@5.7.12':
+    resolution: {integrity: sha512-pLFuZ1PsLkNyY11mx0+IOrMM7xACWCBRxaulfX17osqixkDFeOAyqFGBjh/XxkvRyrDJUdO4F+QHEeSoOiPpgg==}
+    peerDependencies:
+      '@wagmi/core': 2.16.7
+      typescript: '>=5.0.4'
+      viem: 2.x
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@wagmi/connectors@5.7.8':
     resolution: {integrity: sha512-idLCc+GQ/GcGgxakEMC7/NSbpD6r1GB07lfDyEjvI5TMzl18pOZhKiqOTENzNi3hDas6ZMvS1xaGwrWufsb1rA==}
     peerDependencies:
@@ -4747,6 +4761,10 @@ packages:
     resolution: {integrity: sha512-rMvpZS0tQXR/ivzOxN1GkHvw3jRRMlI/jRX5g7ZteLgg2L0ZcANsFvAU5IxILxIKcIkTCloF9TcfloKVbK3qmw==}
     engines: {node: '>=18'}
 
+  '@walletconnect/core@2.19.2':
+    resolution: {integrity: sha512-iu0mgLj51AXcKpdNj8+4EdNNBd/mkNjLEhZn6UMc/r7BM9WbmpPMEydA39WeRLbdLO4kbpmq4wTbiskI1rg+HA==}
+    engines: {node: '>=18'}
+
   '@walletconnect/environment@1.0.1':
     resolution: {integrity: sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==}
 
@@ -4755,6 +4773,9 @@ packages:
 
   '@walletconnect/ethereum-provider@2.19.1':
     resolution: {integrity: sha512-bs8Kiwdw3cGb8ITO8+YymesGfFnucJreQmVbZ0vl/Ogoh38n1T5w0ekjmD/NjTDS3oZaUQyBm3V2UjIBR0qedw==}
+
+  '@walletconnect/ethereum-provider@2.19.2':
+    resolution: {integrity: sha512-NzPzNcjMLqow6ha2nssB1ciMD0cdHZesYcHSQKjCi9waIDMov9Fr2yEJccbiVFE3cxek7f9dCPsoZez2q8ihvg==}
 
   '@walletconnect/events@1.0.1':
     resolution: {integrity: sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==}
@@ -4818,6 +4839,9 @@ packages:
   '@walletconnect/sign-client@2.19.1':
     resolution: {integrity: sha512-OgBHRPo423S02ceN3lAzcZ3MYb1XuLyTTkKqLmKp/icYZCyRzm3/ynqJDKndiBLJ5LTic0y07LiZilnliYqlvw==}
 
+  '@walletconnect/sign-client@2.19.2':
+    resolution: {integrity: sha512-a/K5PRIFPCjfHq5xx3WYKHAAF8Ft2I1LtxloyibqiQOoUtNLfKgFB1r8sdMvXM7/PADNPe4iAw4uSE6PrARrfg==}
+
   '@walletconnect/time@1.0.2':
     resolution: {integrity: sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==}
 
@@ -4827,17 +4851,26 @@ packages:
   '@walletconnect/types@2.19.1':
     resolution: {integrity: sha512-XWWGLioddH7MjxhyGhylL7VVariVON2XatJq/hy0kSGJ1hdp31z194nHN5ly9M495J9Hw8lcYjGXpsgeKvgxzw==}
 
+  '@walletconnect/types@2.19.2':
+    resolution: {integrity: sha512-/LZWhkVCUN+fcTgQUxArxhn2R8DF+LSd/6Wh9FnpjeK/Sdupx1EPS8okWG6WPAqq2f404PRoNAfQytQ82Xdl3g==}
+
   '@walletconnect/universal-provider@2.17.0':
     resolution: {integrity: sha512-d3V5Be7AqLrvzcdMZSBS8DmGDRdqnyLk1DWmRKAGgR6ieUWykhhUKlvfeoZtvJrIXrY7rUGYpH1X41UtFkW5Pw==}
 
   '@walletconnect/universal-provider@2.19.1':
     resolution: {integrity: sha512-4rdLvJ2TGDIieNWW3sZw2MXlX65iHpTuKb5vyvUHQtjIVNLj+7X/09iUAI/poswhtspBK0ytwbH+AIT/nbGpjg==}
 
+  '@walletconnect/universal-provider@2.19.2':
+    resolution: {integrity: sha512-LkKg+EjcSUpPUhhvRANgkjPL38wJPIWumAYD8OK/g4OFuJ4W3lS/XTCKthABQfFqmiNbNbVllmywiyE44KdpQg==}
+
   '@walletconnect/utils@2.17.0':
     resolution: {integrity: sha512-1aeQvjwsXy4Yh9G6g2eGmXrEl+BzkNjHRdCrGdMYqFTFa8ROEJfTGsSH3pLsNDlOY94CoBUvJvM55q/PMoN/FQ==}
 
   '@walletconnect/utils@2.19.1':
     resolution: {integrity: sha512-aOwcg+Hpph8niJSXLqkU25pmLR49B8ECXp5gFQDW5IeVgXHoOoK7w8a79GBhIBheMLlIt1322sTKQ7Rq5KzzFg==}
+
+  '@walletconnect/utils@2.19.2':
+    resolution: {integrity: sha512-VU5CcUF4sZDg8a2/ov29OJzT3KfLuZqJUM0GemW30dlipI5fkpb0VPenZK7TcdLPXc1LN+Q+7eyTqHRoAu/BIA==}
 
   '@walletconnect/window-getters@1.0.1':
     resolution: {integrity: sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==}
@@ -8556,9 +8589,6 @@ packages:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  preact@10.26.2:
-    resolution: {integrity: sha512-0gNmv4qpS9HaN3+40CLBAnKe0ZfyE4ZWo5xKlC1rVrr0ckkEvJvAQqKaHANdFKsGstoxrY4AItZ7kZSGVoVjgg==}
-
   preact@10.26.4:
     resolution: {integrity: sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==}
 
@@ -11630,7 +11660,7 @@ snapshots:
       '@noble/hashes': 1.7.1
       clsx: 1.2.1
       eventemitter3: 5.0.1
-      preact: 10.26.2
+      preact: 10.26.4
 
   '@confio/ics23@0.6.8':
     dependencies:
@@ -16719,6 +16749,45 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@wagmi/connectors@5.7.12(@types/react@18.3.18)(@wagmi/core@2.16.7(@tanstack/query-core@5.24.8)(@types/react@18.3.18)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.21.19(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)':
+    dependencies:
+      '@coinbase/wallet-sdk': 4.3.0
+      '@metamask/sdk': 0.32.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@safe-global/safe-apps-provider': 0.18.5(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@wagmi/core': 2.16.7(@tanstack/query-core@5.24.8)(@types/react@18.3.18)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.21.19(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4))
+      '@walletconnect/ethereum-provider': 2.19.2(@types/react@18.3.18)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
+      viem: 2.21.19(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+    optionalDependencies:
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - supports-color
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@wagmi/connectors@5.7.8(@types/react@18.3.18)(@wagmi/core@2.16.5(@tanstack/query-core@5.24.8)(@types/react@18.3.18)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.21.19(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.21.19(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)':
     dependencies:
       '@coinbase/wallet-sdk': 4.3.0
@@ -16925,6 +16994,49 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/core@2.19.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)':
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.19.2
+      '@walletconnect/utils': 2.19.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/window-getters': 1.0.1
+      es-toolkit: 1.33.0
+      events: 3.3.0
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/environment@1.0.1':
     dependencies:
       tslib: 1.14.1
@@ -16978,6 +17090,46 @@ snapshots:
       '@walletconnect/types': 2.19.1
       '@walletconnect/universal-provider': 2.19.1(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@walletconnect/utils': 2.19.1(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/ethereum-provider@2.19.2(@types/react@18.3.18)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)':
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/modal': 2.7.0(@types/react@18.3.18)(react@18.3.1)
+      '@walletconnect/sign-client': 2.19.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/types': 2.19.2
+      '@walletconnect/universal-provider': 2.19.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/utils': 2.19.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -17210,6 +17362,41 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/sign-client@2.19.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)':
+    dependencies:
+      '@walletconnect/core': 2.19.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.19.2
+      '@walletconnect/utils': 2.19.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/time@1.0.2':
     dependencies:
       tslib: 1.14.1
@@ -17243,6 +17430,34 @@ snapshots:
       - uploadthing
 
   '@walletconnect/types@2.19.1':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - uploadthing
+
+  '@walletconnect/types@2.19.2':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
@@ -17343,6 +17558,45 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/universal-provider@2.19.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/sign-client': 2.19.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/types': 2.19.2
+      '@walletconnect/utils': 2.19.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+      es-toolkit: 1.33.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/utils@2.17.0':
     dependencies:
       '@stablelib/chacha20poly1305': 1.0.1
@@ -17398,6 +17652,49 @@ snapshots:
       bs58: 6.0.0
       detect-browser: 5.3.0
       elliptic: 6.6.1
+      query-string: 7.1.3
+      uint8arrays: 3.1.0
+      viem: 2.23.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/utils@2.19.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)':
+    dependencies:
+      '@noble/ciphers': 1.2.1
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.19.2
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      bs58: 6.0.0
+      detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
       viem: 2.23.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -18999,7 +19296,7 @@ snapshots:
       eslint: 9.22.0(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@1.21.7))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@1.21.7))(typescript@5.8.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@1.21.7)))(eslint@9.22.0(jiti@1.21.7))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@1.21.7))(typescript@5.8.2))(eslint-import-resolver-typescript@2.7.1)(eslint@9.22.0(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.22.0(jiti@1.21.7))
       eslint-plugin-react: 7.37.4(eslint@9.22.0(jiti@1.21.7))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.22.0(jiti@1.21.7))
@@ -19045,7 +19342,7 @@ snapshots:
       stable-hash: 0.0.4
       tinyglobby: 0.2.12
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@1.21.7))(typescript@5.8.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@1.21.7)))(eslint@9.22.0(jiti@1.21.7))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@1.21.7))(typescript@5.8.2))(eslint-import-resolver-typescript@2.7.1)(eslint@9.22.0(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -19060,51 +19357,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@1.21.7))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.22.0(jiti@1.21.7)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.26.1(eslint@9.22.0(jiti@1.21.7))(typescript@5.8.2)
-      eslint: 9.22.0(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@1.21.7))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-plugin-es@3.0.1(eslint@9.22.0(jiti@1.21.7)):
     dependencies:
       eslint: 9.22.0(jiti@1.21.7)
       eslint-utils: 2.1.0
       regexpp: 3.2.0
-
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@1.21.7))(typescript@5.8.2))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@1.21.7)))(eslint@9.22.0(jiti@1.21.7)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.22.0(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@1.21.7))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.22.0(jiti@1.21.7))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.26.1(eslint@9.22.0(jiti@1.21.7))(typescript@5.8.2)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
 
   eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@1.21.7))(typescript@5.8.2))(eslint-import-resolver-typescript@2.7.1)(eslint@9.22.0(jiti@1.21.7)):
     dependencies:
@@ -21895,8 +22152,6 @@ snapshots:
       nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  preact@10.26.2: {}
 
   preact@10.26.4: {}
 


### PR DESCRIPTION
Addded transaction helpers to implement BridgeSwap. These can also be used in other scenarios.
- getTransferFromCall: Pulls funds from `funder` using `ERC20.transferFrom` or `Permit2.transferFrom` if balance insufficient
- getApprovalCall: Sets approval for `spender` using `ERC.approve` if allowance insufficient
- getPermit2ApprovalCall: Same as `getApprovalCall` but using Permit2
- getTransferRemoteWithApprovalCalls: Calls `TokenRouter.transferRemote` and sets approvals if needed beforehand
- getTransferRemoteCalls: Pulls funds, sets approvals and calls `TokenRouter.transferRemote`

These helpers are designed as follows:
- Takes as first 2 params `queryClient: QueryClient, wagmiConfig: Config`
- Use `queryClient.fetchQuery(readContractQueryOptions(...))` to make cached read calls using Tanstack QueryClient & Wagmi Query Option builders
- Return `call` / `calls`: List of encoded calls

 