### PR TITLE
fix search params bug

### DIFF
--- a/packages/veraswap-app/src/components/token-selector.tsx
+++ b/packages/veraswap-app/src/components/token-selector.tsx
@@ -5,20 +5,16 @@ import { Chain } from "viem";
 import { groupBy } from "lodash-es";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { Token } from "@owlprotocol/veraswap-sdk";
-import { useSearch } from "@tanstack/react-router";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog.js";
 import { Button } from "@/components/ui/button.js";
 import { Input } from "@/components/ui/input.js";
 import { cn } from "@/lib/utils.js";
 import { chainsAtom, tokensAtom, tokenInAtom, tokenOutAtom, chainsTypeAtom } from "@/atoms/index.js";
-import { Route } from "@/routes/index.js";
 import { useSyncSwapSearchParams } from "@/hooks/useSyncSwapSearchParams.js";
 import { tokenBalancesAtom } from "@/atoms/token-balance.js";
 
 export const TokenSelector = ({ selectingTokenIn }: { selectingTokenIn?: boolean }) => {
-    const search = useSearch({ from: "/" });
-    const navigate = Route.useNavigate();
     const [isOpen, setIsOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState("");
     const [expandedSymbol, setExpandedSymbol] = useState<string | null>(null);
@@ -63,26 +59,8 @@ export const TokenSelector = ({ selectingTokenIn }: { selectingTokenIn?: boolean
     const handleTokenSelect = (token: Token) => {
         if (selectingTokenIn) {
             setTokenIn(token);
-            navigate({
-                search: {
-                    ...search,
-                    type: networkType,
-                    tokenIn: token.symbol,
-                    chainIdIn: token.chainId,
-                },
-                replace: true,
-            });
         } else {
             setTokenOut(token);
-            navigate({
-                search: {
-                    ...search,
-                    type: networkType,
-                    tokenOut: token.symbol,
-                    chainIdOut: token.chainId,
-                },
-                replace: true,
-            });
         }
         setExpandedSymbol(null);
         setIsOpen(false);

--- a/packages/veraswap-app/src/hooks/useSyncSwapSearchParams.ts
+++ b/packages/veraswap-app/src/hooks/useSyncSwapSearchParams.ts
@@ -46,15 +46,19 @@ export function useSyncSwapSearchParams(allTokens: Token[]) {
     }, [allTokens, search]);
 
     useEffect(() => {
-        if (!tokenIn || !tokenOut) return;
+        if (!tokenIn && !tokenOut) return;
 
         navigate({
             search: (prev) => ({
                 ...prev,
-                tokenIn: tokenIn.symbol,
-                chainIdIn: tokenIn.chainId,
-                tokenOut: tokenOut.symbol,
-                chainIdOut: tokenOut.chainId,
+                ...(tokenIn && {
+                    tokenIn: tokenIn.symbol,
+                    chainIdIn: tokenIn.chainId,
+                }),
+                ...(tokenOut && {
+                    tokenOut: tokenOut.symbol,
+                    chainIdOut: tokenOut.chainId,
+                }),
             }),
             replace: true,
         });

--- a/packages/veraswap-app/src/hooks/useSyncSwapSearchParams.ts
+++ b/packages/veraswap-app/src/hooks/useSyncSwapSearchParams.ts
@@ -8,8 +8,9 @@ import { Route } from "@/routes/index.js";
 export function useSyncSwapSearchParams(allTokens: Token[]) {
     const navigate = Route.useNavigate();
     const search = useSearch({ from: "/" });
-    const [, setTokenIn] = useAtom(tokenInAtom);
-    const [, setTokenOut] = useAtom(tokenOutAtom);
+
+    const [tokenIn, setTokenIn] = useAtom(tokenInAtom);
+    const [tokenOut, setTokenOut] = useAtom(tokenOutAtom);
     const [, setNetworkType] = useAtom(chainsTypeWriteAtom);
     const [enabledChains] = useAtom(chainsAtom);
 
@@ -17,6 +18,21 @@ export function useSyncSwapSearchParams(allTokens: Token[]) {
         const { tokenIn: tokenInSymbol, chainIdIn, tokenOut: tokenOutSymbol, chainIdOut, type } = search;
 
         const chainsType = type ?? "mainnet";
+        setNetworkType(chainsType);
+
+        const enabledChainIds = enabledChains.map((c) => c.id);
+        const tokensInNetwork = allTokens.filter((t) => enabledChainIds.includes(t.chainId));
+
+        if (tokenInSymbol && chainIdIn) {
+            const foundTokenIn = tokensInNetwork.find((t) => t.symbol === tokenInSymbol && t.chainId === chainIdIn);
+            if (foundTokenIn) setTokenIn(foundTokenIn);
+        }
+
+        if (tokenOutSymbol && chainIdOut) {
+            const foundTokenOut = tokensInNetwork.find((t) => t.symbol === tokenOutSymbol && t.chainId === chainIdOut);
+            if (foundTokenOut) setTokenOut(foundTokenOut);
+        }
+
         if (!type) {
             navigate({
                 search: {
@@ -25,27 +41,23 @@ export function useSyncSwapSearchParams(allTokens: Token[]) {
                 },
                 replace: true,
             });
-            return;
-        }
-
-        setNetworkType(chainsType);
-
-        const enabledChainIds = enabledChains.map((c) => c.id);
-        const tokensInNetwork = allTokens.filter((t) => enabledChainIds.includes(t.chainId));
-
-        if (tokenInSymbol && chainIdIn) {
-            const foundTokenIn = tokensInNetwork.find((t) => t.symbol === tokenInSymbol && t.chainId === chainIdIn);
-            if (foundTokenIn) {
-                setTokenIn(foundTokenIn);
-            }
-        }
-
-        if (tokenOutSymbol && chainIdOut) {
-            const foundTokenOut = tokensInNetwork.find((t) => t.symbol === tokenOutSymbol && t.chainId === chainIdOut);
-            if (foundTokenOut) {
-                setTokenOut(foundTokenOut);
-            }
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [allTokens, search]);
+
+    useEffect(() => {
+        if (!tokenIn || !tokenOut) return;
+
+        navigate({
+            search: (prev) => ({
+                ...prev,
+                tokenIn: tokenIn.symbol,
+                chainIdIn: tokenIn.chainId,
+                tokenOut: tokenOut.symbol,
+                chainIdOut: tokenOut.chainId,
+            }),
+            replace: true,
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [tokenIn, tokenOut]);
 }


### PR DESCRIPTION
Url does not get updated when we invert tokens.
- Removed navigation logic from token picker 
- encapsulate search params logic in useSyncSwapSearchParams hook 
- separate effect that listens for tokenIn tokenOut changes