### PR TITLE
Simple V4 Multihop Routes

### DIFF
--- a/packages/veraswap-app/src/atoms/atoms.ts
+++ b/packages/veraswap-app/src/atoms/atoms.ts
@@ -3,9 +3,10 @@ import { atomWithMutation, atomWithQuery } from "jotai-tanstack-query";
 import { isMultichainToken, TransactionType } from "@owlprotocol/veraswap-sdk";
 import { Hash } from "viem";
 import { sendTransactionMutationOptions, waitForTransactionReceiptQueryOptions } from "wagmi/query";
-import { tokenInAmountAtom, currencyInAtom, transactionTypeAtom, currencyOutAtom } from "./tokens.js";
+import { tokenInAmountAtom, currencyInAtom, currencyOutAtom } from "./tokens.js";
 import { accountAtom } from "./account.js";
 import { tokenInAccountBalanceAtom, tokenInAllowanceAccountToPermit2Atom } from "./token-balance.js";
+import { submittedTransactionTypeAtom, transactionTypeAtom } from "./uniswap.js";
 import { config } from "@/config.js";
 import { TransactionStep } from "@/components/TransactionStatusModal.js";
 
@@ -203,4 +204,5 @@ export const resetTransactionStateAtom = atom(null, (_, set) => {
     set(superchainBridgeMessageIdAtom, null);
     set(bridgeMessageIdAtom, null);
     set(swapMessageIdAtom, null);
+    set(submittedTransactionTypeAtom, null);
 });

--- a/packages/veraswap-app/src/atoms/orbiter.ts
+++ b/packages/veraswap-app/src/atoms/orbiter.ts
@@ -2,14 +2,8 @@ import { atom } from "jotai";
 import { chainIdToOrbiterChainId, OrbiterParams, orbiterRoutersQueryOptions } from "@owlprotocol/veraswap-sdk";
 import { atomWithQuery } from "jotai-tanstack-query";
 import { zeroAddress, Address, parseUnits } from "viem";
-import {
-    chainInAtom,
-    chainOutAtom,
-    tokenInAmountAtom,
-    currencyInAtom,
-    currencyOutAtom,
-    transactionTypeAtom,
-} from "./tokens.js";
+import { chainInAtom, chainOutAtom, tokenInAmountAtom, currencyInAtom, currencyOutAtom } from "./tokens.js";
+import { transactionTypeAtom } from "./uniswap.js";
 
 const orbiterRoutersMainnet = atomWithQuery(() => orbiterRoutersQueryOptions(true));
 const orbiterRoutersTestnet = atomWithQuery(() => orbiterRoutersQueryOptions(false));

--- a/packages/veraswap-app/src/atoms/tokens.ts
+++ b/packages/veraswap-app/src/atoms/tokens.ts
@@ -1,8 +1,6 @@
 import { atom } from "jotai";
 import { parseUnits } from "viem";
-import { getTransactionType, TransactionType, Currency } from "@owlprotocol/veraswap-sdk";
-import { POOLS } from "@owlprotocol/veraswap-sdk/constants";
-import { routeMultichainAtom } from "./uniswap.js";
+import { Currency } from "@owlprotocol/veraswap-sdk";
 import { chains } from "@/config.js";
 
 /***** Tokens Fetch *****/
@@ -60,18 +58,6 @@ export const currencyOutAtom = atom<Currency | null>(null);
 export const chainOutAtom = atom((get) => {
     const currencyOut = get(currencyOutAtom);
     return chains.find((c) => c.id === currencyOut?.chainId) ?? null;
-});
-
-/** Find transaction type (BRIDGE, SWAP, SWAP_BRIDGE, BRIDGE_SWAP) */
-export const transactionTypeAtom = atom<TransactionType | null>((get) => {
-    const currencyIn = get(currencyInAtom);
-    const currencyOut = get(currencyOutAtom);
-
-    const routeMultichain = get(routeMultichainAtom).data;
-    if (!currencyIn || !currencyOut || !routeMultichain) return null;
-
-    //TODO: Add better constants
-    return getTransactionType({ currencyIn, currencyOut, routeComponents: routeMultichain.flows });
 });
 
 /***** Invert *****/

--- a/packages/veraswap-app/src/atoms/tokens.ts
+++ b/packages/veraswap-app/src/atoms/tokens.ts
@@ -2,6 +2,7 @@ import { atom } from "jotai";
 import { parseUnits } from "viem";
 import { getTransactionType, TransactionType, Currency } from "@owlprotocol/veraswap-sdk";
 import { POOLS } from "@owlprotocol/veraswap-sdk/constants";
+import { routeMultichainAtom } from "./uniswap.js";
 import { chains } from "@/config.js";
 
 /***** Tokens Fetch *****/
@@ -65,10 +66,12 @@ export const chainOutAtom = atom((get) => {
 export const transactionTypeAtom = atom<TransactionType | null>((get) => {
     const currencyIn = get(currencyInAtom);
     const currencyOut = get(currencyOutAtom);
-    if (!currencyIn || !currencyOut) return null;
+
+    const routeMultichain = get(routeMultichainAtom).data;
+    if (!currencyIn || !currencyOut || !routeMultichain) return null;
 
     //TODO: Add better constants
-    return getTransactionType({ currencyIn, currencyOut, poolKeys: POOLS });
+    return getTransactionType({ currencyIn, currencyOut, routeComponents: routeMultichain });
 });
 
 /***** Invert *****/

--- a/packages/veraswap-app/src/atoms/tokens.ts
+++ b/packages/veraswap-app/src/atoms/tokens.ts
@@ -71,7 +71,7 @@ export const transactionTypeAtom = atom<TransactionType | null>((get) => {
     if (!currencyIn || !currencyOut || !routeMultichain) return null;
 
     //TODO: Add better constants
-    return getTransactionType({ currencyIn, currencyOut, routeComponents: routeMultichain });
+    return getTransactionType({ currencyIn, currencyOut, routeComponents: routeMultichain.flows });
 });
 
 /***** Invert *****/

--- a/packages/veraswap-app/src/atoms/uniswap.ts
+++ b/packages/veraswap-app/src/atoms/uniswap.ts
@@ -1,6 +1,11 @@
 import { atomWithQuery, AtomWithQueryResult, queryClientAtom } from "jotai-tanstack-query";
-import { getRouteMultichain, getUniswapV4Address } from "@owlprotocol/veraswap-sdk";
-import { Atom } from "jotai";
+import {
+    getRouteMultichain,
+    getUniswapV4Address,
+    getTransactionType,
+    TransactionType,
+} from "@owlprotocol/veraswap-sdk";
+import { atom, Atom } from "jotai";
 import { numberToHex } from "viem";
 import { UNISWAP_CONTRACTS } from "@owlprotocol/veraswap-sdk/constants";
 import { queryOptions } from "@tanstack/react-query";
@@ -47,3 +52,17 @@ export const routeMultichainAtom = atomWithQuery((get) => {
         ],
     });
 }) as Atom<AtomWithQueryResult<Awaited<ReturnType<typeof getRouteMultichain>>>>;
+
+/** Find transaction type (BRIDGE, SWAP, SWAP_BRIDGE, BRIDGE_SWAP) */
+export const transactionTypeAtom = atom<TransactionType | null>((get) => {
+    const currencyIn = get(currencyInAtom);
+    const currencyOut = get(currencyOutAtom);
+
+    const routeMultichain = get(routeMultichainAtom).data;
+    if (!currencyIn || !currencyOut || !routeMultichain) return null;
+
+    //TODO: Add better constants
+    return getTransactionType({ currencyIn, currencyOut, routeComponents: routeMultichain.flows });
+});
+
+export const submittedTransactionTypeAtom = atom<TransactionType | null>(null);

--- a/packages/veraswap-app/src/atoms/uniswap.ts
+++ b/packages/veraswap-app/src/atoms/uniswap.ts
@@ -1,23 +1,11 @@
 import { atomWithQuery, AtomWithQueryResult, queryClientAtom } from "jotai-tanstack-query";
-import {
-    getRouteMultichain,
-    getUniswapV4Address,
-    isMultichainToken,
-    PoolKey,
-    quoteQueryOptions,
-} from "@owlprotocol/veraswap-sdk";
+import { getRouteMultichain, getUniswapV4Address, PoolKey, quoteQueryOptions } from "@owlprotocol/veraswap-sdk";
 import { Token, CurrencyAmount, Ether } from "@uniswap/sdk-core";
-import { Atom, atom, WritableAtom } from "jotai";
-import { Address, zeroAddress } from "viem";
+import { Atom, WritableAtom } from "jotai";
+import { Address, numberToHex, zeroAddress } from "viem";
 import { UNISWAP_CONTRACTS } from "@owlprotocol/veraswap-sdk/constants";
 import { queryOptions } from "@tanstack/react-query";
-import {
-    currencyInAtom,
-    currencyOutAtom,
-    tokenInAmountAtom,
-    tokenInAmountInputAtom,
-    transactionTypeAtom,
-} from "./tokens.js";
+import { currencyInAtom, currencyOutAtom, tokenInAmountAtom, transactionTypeAtom } from "./tokens.js";
 import { orbiterAmountOutAtom } from "./orbiter.js";
 import { disabledQueryOptions } from "./disabledQuery.js";
 import { config } from "@/config.js";
@@ -123,7 +111,7 @@ export const routeMultichainAtom = atomWithQuery((get) => {
             currencyInAddress,
             currencyOut.chainId,
             currencyOutAddress,
-            exactAmount,
+            numberToHex(exactAmount),
         ],
     });
 }) as Atom<AtomWithQueryResult<Awaited<ReturnType<typeof getRouteMultichain>>>>;

--- a/packages/veraswap-app/src/atoms/uniswap.ts
+++ b/packages/veraswap-app/src/atoms/uniswap.ts
@@ -100,6 +100,9 @@ export const routeMultichainAtom = atomWithQuery((get) => {
 
     if (!currencyIn || !currencyOut || !exactAmount) return disabledQueryOptions as any;
 
+    const currencyInAddress = getUniswapV4Address(currencyIn);
+    const currencyOutAddress = getUniswapV4Address(currencyOut);
+
     return queryOptions({
         queryFn: async () => {
             const route = await getRouteMultichain(queryClient, config, {
@@ -114,6 +117,13 @@ export const routeMultichainAtom = atomWithQuery((get) => {
 
             return route;
         },
-        queryKey: ["getRouteMultichain"],
+        queryKey: [
+            "getRouteMultichain",
+            currencyIn.chainId,
+            currencyInAddress,
+            currencyOut.chainId,
+            currencyOutAddress,
+            exactAmount,
+        ],
     });
 }) as Atom<AtomWithQueryResult<Awaited<ReturnType<typeof getRouteMultichain>>>>;

--- a/packages/veraswap-app/src/atoms/uniswap.ts
+++ b/packages/veraswap-app/src/atoms/uniswap.ts
@@ -1,83 +1,15 @@
 import { atomWithQuery, AtomWithQueryResult, queryClientAtom } from "jotai-tanstack-query";
-import { getRouteMultichain, getUniswapV4Address, PoolKey, quoteQueryOptions } from "@owlprotocol/veraswap-sdk";
-import { Token, CurrencyAmount, Ether } from "@uniswap/sdk-core";
-import { Atom, WritableAtom } from "jotai";
-import { Address, numberToHex, zeroAddress } from "viem";
+import { getRouteMultichain, getUniswapV4Address } from "@owlprotocol/veraswap-sdk";
+import { Atom } from "jotai";
+import { numberToHex } from "viem";
 import { UNISWAP_CONTRACTS } from "@owlprotocol/veraswap-sdk/constants";
 import { queryOptions } from "@tanstack/react-query";
-import { currencyInAtom, currencyOutAtom, tokenInAmountAtom, transactionTypeAtom } from "./tokens.js";
-import { orbiterAmountOutAtom } from "./orbiter.js";
+import { currencyInAtom, currencyOutAtom, tokenInAmountAtom } from "./tokens.js";
 import { disabledQueryOptions } from "./disabledQuery.js";
 import { config } from "@/config.js";
 
 // const emptyToken = new Token(1, zeroAddress, 1);
 // const emptyCurrencyAmount = CurrencyAmount.fromRawAmount(emptyToken, 1);
-const emptyPoolKey = {
-    currency0: zeroAddress,
-    currency1: zeroAddress,
-    fee: 3_000,
-    tickSpacing: 60,
-    hooks: zeroAddress,
-};
-
-/** v4Quoter.quoteExactInputSingle(...): QueryResult */
-export const quoteInAtom = atomWithQuery((get) => {
-    const tokenInAmount = get(tokenInAmountAtom);
-
-    const transactionType = get(transactionTypeAtom);
-
-    const orbiterAmountOut = get(orbiterAmountOutAtom);
-
-    let chainId: number = 0;
-    let poolKey: PoolKey = emptyPoolKey;
-    let tokenInAddress: Address = zeroAddress;
-    let tokenInDecimals = 18;
-
-    if (transactionType?.type === "SWAP") {
-        chainId = transactionType.chainId;
-        poolKey = transactionType.poolKey;
-        const currencyIn = transactionType.currencyIn;
-        tokenInAddress = getUniswapV4Address(currencyIn);
-        tokenInDecimals = tokenInDecimals;
-    } else if (transactionType?.type === "SWAP_BRIDGE" || transactionType?.type === "BRIDGE_SWAP") {
-        chainId = transactionType.swap.chainId;
-        poolKey = transactionType.swap.poolKey;
-        const currencyIn = transactionType.swap.currencyIn;
-        tokenInAddress = getUniswapV4Address(currencyIn);
-        tokenInDecimals = currencyIn.decimals;
-    }
-
-    const quoterAddress = chainId ? UNISWAP_CONTRACTS[chainId]?.v4Quoter : zeroAddress;
-
-    if (!quoterAddress) {
-        console.warn("Quoter address not found for chain id ", chainId);
-    }
-
-    const enabled = chainId != 0 && poolKey != emptyPoolKey && !!tokenInAmount && !!quoterAddress;
-
-    let amountIn = tokenInAmount;
-
-    // TODO: generalize to any bridging that involves orbiter (e.g. USDC)
-    if (transactionType?.type === "BRIDGE_SWAP" && transactionType?.bridge.currencyIn.isNative && orbiterAmountOut) {
-        amountIn = orbiterAmountOut;
-    }
-
-    // Query args MUST be defined
-    const currencyIn =
-        tokenInAddress === zeroAddress ? Ether.onChain(chainId) : new Token(chainId, tokenInAddress, tokenInDecimals);
-    const exactCurrencyAmount = CurrencyAmount.fromRawAmount(currencyIn, (amountIn ?? 0).toString());
-
-    return {
-        ...quoteQueryOptions(config, {
-            chainId,
-            poolKey,
-            exactCurrencyAmount,
-            quoteType: "quoteExactInputSingle",
-            quoterAddress: quoterAddress!,
-        }),
-        enabled,
-    };
-}) as unknown as WritableAtom<AtomWithQueryResult<[bigint, bigint], Error>, [], void>;
 
 //TODO: As tanstack query so that it refreshes
 export const routeMultichainAtom = atomWithQuery((get) => {

--- a/packages/veraswap-app/src/components/TransactionStatusModal.tsx
+++ b/packages/veraswap-app/src/components/TransactionStatusModal.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card.js";
 import { cn } from "@/lib/utils.js";
 import { TransactionStepId } from "@/atoms/atoms.js";
-import { transactionTypeAtom } from "@/atoms/tokens.js";
+import { transactionTypeAtom } from "@/atoms/uniswap.js";
 
 export type TransactionStep = {
     id: TransactionStepId;

--- a/packages/veraswap-app/src/components/token-selector.tsx
+++ b/packages/veraswap-app/src/components/token-selector.tsx
@@ -408,6 +408,7 @@ const TokenGroup = ({
     );
 };
 
+// TODO: Fix "Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render."
 const ChainTokenBalance = ({
     token,
     chain,

--- a/packages/veraswap-app/src/components/token-selector.tsx
+++ b/packages/veraswap-app/src/components/token-selector.tsx
@@ -284,24 +284,38 @@ const TokenGroup = ({
     const account = useAtomValue(accountAtom);
     const { balance: totalBalance } = useAtomValue(currencyMultichainBalanceAtomFamily(symbol));
 
-    const balanceAtoms = tokenList.map((token) =>
-        account?.address ? currencyBalanceAtomFamily({ currency: token, account: account.address }) : atom(null),
+    // Inspired from https://github.com/pmndrs/jotai/issues/454#issuecomment-829779749
+    const balanceValues = useAtomValue(
+        useMemo(
+            () =>
+                atom((get) => {
+                    const balanceAtoms = tokenList.map((token) =>
+                        account?.address
+                            ? currencyBalanceAtomFamily({ currency: token, account: account.address })
+                            : atom(null),
+                    );
+
+                    return balanceAtoms.map((atom) => get(atom));
+                }),
+            [account.address, tokenList],
+        ),
     );
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const balanceValues = balanceAtoms.map((atom) => useAtomValue(atom));
+    const [tokensWithBalance, tokensWithoutBalance] = useMemo(() => {
+        const tokensWithBalance: Currency[] = [];
+        const tokensWithoutBalance: Currency[] = [];
 
-    const tokensWithBalance: Currency[] = [];
-    const tokensWithoutBalance: Currency[] = [];
+        tokenList.forEach((token, index) => {
+            const balance = balanceValues[index];
+            if (balance?.data && balance.data > 0n) {
+                tokensWithBalance.push(token);
+            } else {
+                tokensWithoutBalance.push(token);
+            }
+        });
 
-    tokenList.forEach((token, index) => {
-        const balance = balanceValues[index];
-        if (balance?.data && balance.data > 0n) {
-            tokensWithBalance.push(token);
-        } else {
-            tokensWithoutBalance.push(token);
-        }
-    });
+        return [tokensWithBalance, tokensWithoutBalance];
+    }, [balanceValues, tokenList]);
 
     useEffect(() => {
         if (isExpanded && ref.current) {

--- a/packages/veraswap-app/src/routes/index.tsx
+++ b/packages/veraswap-app/src/routes/index.tsx
@@ -431,7 +431,6 @@ function Index() {
                     },
                 },
             );
-            setTokenInAmountInput("");
         }
     };
 

--- a/packages/veraswap-app/src/routes/index.tsx
+++ b/packages/veraswap-app/src/routes/index.tsx
@@ -32,7 +32,6 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import {
-    quoteInAtom,
     sendTransactionMutationAtom,
     swapInvertAtom,
     SwapStep,
@@ -126,7 +125,7 @@ function Index() {
     const { data: bridgePayment } = useAtomValue(tokenRouterQuoteGasPaymentQueryAtom);
 
     const { data: kernelSmartAccountInitData } = useAtomValue(kernelInitDataAtom);
-    const { data: quoterData, error: quoterError, isLoading: isQuoterLoading } = useAtomValue(quoteInAtom);
+    const { data: quoterData, error: quoterError, isLoading: isQuoterLoading } = useAtomValue(routeMultichainAtom);
 
     const [tokenInAmountInput, setTokenInAmountInput] = useAtom(tokenInAmountInputAtom);
     const [, swapInvert] = useAtom(swapInvertAtom);
@@ -196,7 +195,7 @@ function Index() {
                 ? formatUnits(orbiterAmountOut ?? 0n, currencyOut?.decimals ?? 18)
                 : formatUnits(tokenInAmount ?? 0n, currencyOut?.decimals ?? 18)
             : quoterData
-              ? formatUnits(quoterData[0], currencyOut?.decimals ?? 18)
+              ? formatUnits(quoterData.amountOut, currencyOut?.decimals ?? 18)
               : "";
 
     useDustAccount(walletAddress);
@@ -305,8 +304,8 @@ function Index() {
             // NOTE: should be inferred from the top level check of handleSwapSteps
             if (!transactionType) return;
 
-            // const amountOutMinimum = transactionType.type === "BRIDGE" ? null : quoterData![0];
-            const amountOutMinimum = quoterData?.[0] ?? null;
+            // const amountOutMinimum = transactionType.type === "BRIDGE" ? null : quoterData?.amountOut;
+            const amountOutMinimum = quoterData?.amountOut ?? null;
             if (transactionType.type !== "BRIDGE" && !amountOutMinimum) {
                 throw new Error("amountOutMinimum is required for this transaction type");
             }

--- a/packages/veraswap-app/src/routes/index.tsx
+++ b/packages/veraswap-app/src/routes/index.tsx
@@ -400,7 +400,10 @@ function Index() {
                 return;
             }
 
-            setSubmittedTransactionType(transactionType);
+            // Make a copy the next to awaitable function call from racing
+            const submittedTransactionType = { ...transactionType };
+
+            setSubmittedTransactionType(submittedTransactionType);
 
             sendTransaction(
                 { chainId: currencyIn.chainId, ...transaction },

--- a/packages/veraswap-app/src/routes/index.tsx
+++ b/packages/veraswap-app/src/routes/index.tsx
@@ -196,8 +196,8 @@ function Index() {
                 ? formatUnits(orbiterAmountOut ?? 0n, currencyOut?.decimals ?? 18)
                 : formatUnits(tokenInAmount ?? 0n, currencyOut?.decimals ?? 18)
             : quoterData
-                ? formatUnits(quoterData[0], currencyOut?.decimals ?? 18)
-                : "";
+              ? formatUnits(quoterData[0], currencyOut?.decimals ?? 18)
+              : "";
 
     const routeMultichain = useAtomValue(routeMultichainAtom);
 
@@ -319,17 +319,17 @@ function Index() {
             const transactionParams =
                 transactionType.type === "BRIDGE"
                     ? ({
-                        ...transactionType,
-                        amountIn: tokenInAmount!,
-                        walletAddress,
-                        bridgePayment: bridgePayment,
-                        orbiterParams,
-                        queryClient: queryClient,
-                        wagmiConfig: config,
-                        initData: kernelSmartAccountInitData,
-                    } as TransactionParams & TransactionTypeBridge)
+                          ...transactionType,
+                          amountIn: tokenInAmount!,
+                          walletAddress,
+                          bridgePayment: bridgePayment,
+                          orbiterParams,
+                          queryClient: queryClient,
+                          wagmiConfig: config,
+                          initData: kernelSmartAccountInitData,
+                      } as TransactionParams & TransactionTypeBridge)
                     : transactionType.type === "BRIDGE_SWAP"
-                        ? ({
+                      ? ({
                             ...transactionType,
                             amountIn: tokenInAmount!,
                             amountOutMinimum,
@@ -340,7 +340,7 @@ function Index() {
                             wagmiConfig: config,
                             initData: kernelSmartAccountInitData,
                         } as TransactionParams & TransactionTypeBridgeSwap)
-                        : ({
+                      : ({
                             ...transactionType,
                             amountIn: tokenInAmount!,
                             amountOutMinimum: amountOutMinimum!,
@@ -708,8 +708,8 @@ function Index() {
                                         !!quoterError
                                             ? "Insufficient Liquidity"
                                             : isQuoterLoading
-                                                ? "Fetching quote..."
-                                                : "0"
+                                              ? "Fetching quote..."
+                                              : "0"
                                     }
                                     disabled={true}
                                 />

--- a/packages/veraswap-app/src/routes/index.tsx
+++ b/packages/veraswap-app/src/routes/index.tsx
@@ -199,8 +199,6 @@ function Index() {
               ? formatUnits(quoterData[0], currencyOut?.decimals ?? 18)
               : "";
 
-    const routeMultichain = useAtomValue(routeMultichainAtom);
-
     useDustAccount(walletAddress);
 
     useWatchHyperlaneMessageProcessed(

--- a/packages/veraswap-app/src/routes/index.tsx
+++ b/packages/veraswap-app/src/routes/index.tsx
@@ -71,6 +71,7 @@ import {
     chainOutAtom,
     superchainBridgeMessageIdAtom,
     resetTransactionStateAtom,
+    routeMultichainAtom,
 } from "../atoms/index.js";
 import { Button } from "@/components/ui/button.js";
 import { Card, CardContent } from "@/components/ui/card.js";
@@ -195,8 +196,10 @@ function Index() {
                 ? formatUnits(orbiterAmountOut ?? 0n, currencyOut?.decimals ?? 18)
                 : formatUnits(tokenInAmount ?? 0n, currencyOut?.decimals ?? 18)
             : quoterData
-              ? formatUnits(quoterData[0], currencyOut?.decimals ?? 18)
-              : "";
+                ? formatUnits(quoterData[0], currencyOut?.decimals ?? 18)
+                : "";
+
+    const routeMultichain = useAtomValue(routeMultichainAtom);
 
     useDustAccount(walletAddress);
 
@@ -316,17 +319,17 @@ function Index() {
             const transactionParams =
                 transactionType.type === "BRIDGE"
                     ? ({
-                          ...transactionType,
-                          amountIn: tokenInAmount!,
-                          walletAddress,
-                          bridgePayment: bridgePayment,
-                          orbiterParams,
-                          queryClient: queryClient,
-                          wagmiConfig: config,
-                          initData: kernelSmartAccountInitData,
-                      } as TransactionParams & TransactionTypeBridge)
+                        ...transactionType,
+                        amountIn: tokenInAmount!,
+                        walletAddress,
+                        bridgePayment: bridgePayment,
+                        orbiterParams,
+                        queryClient: queryClient,
+                        wagmiConfig: config,
+                        initData: kernelSmartAccountInitData,
+                    } as TransactionParams & TransactionTypeBridge)
                     : transactionType.type === "BRIDGE_SWAP"
-                      ? ({
+                        ? ({
                             ...transactionType,
                             amountIn: tokenInAmount!,
                             amountOutMinimum,
@@ -337,7 +340,7 @@ function Index() {
                             wagmiConfig: config,
                             initData: kernelSmartAccountInitData,
                         } as TransactionParams & TransactionTypeBridgeSwap)
-                      : ({
+                        : ({
                             ...transactionType,
                             amountIn: tokenInAmount!,
                             amountOutMinimum: amountOutMinimum!,
@@ -705,8 +708,8 @@ function Index() {
                                         !!quoterError
                                             ? "Insufficient Liquidity"
                                             : isQuoterLoading
-                                              ? "Fetching quote..."
-                                              : "0"
+                                                ? "Fetching quote..."
+                                                : "0"
                                     }
                                     disabled={true}
                                 />

--- a/packages/veraswap-sdk/script/DeployLocal.s.sol
+++ b/packages/veraswap-sdk/script/DeployLocal.s.sol
@@ -249,7 +249,7 @@ contract DeployLocal is DeployCoreContracts {
 
         PoolUtils.setupToken(IERC20(tokenA), IPositionManager(v4PositionManager), IUniversalRouter(router));
         PoolUtils.setupToken(IERC20(tokenB), IPositionManager(v4PositionManager), IUniversalRouter(router));
-        // PoolUtils.deployPool(tokenA, tokenB, IPositionManager(v4PositionManager), IStateView(v4StateView));
+        PoolUtils.deployPool(tokenA, tokenB, IPositionManager(v4PositionManager), IStateView(v4StateView));
         PoolUtils.deployPool(tokenA, address(0), IPositionManager(v4PositionManager), IStateView(v4StateView));
         PoolUtils.deployPool(tokenB, address(0), IPositionManager(v4PositionManager), IStateView(v4StateView));
 

--- a/packages/veraswap-sdk/script/DeployLocal.s.sol
+++ b/packages/veraswap-sdk/script/DeployLocal.s.sol
@@ -249,7 +249,7 @@ contract DeployLocal is DeployCoreContracts {
 
         PoolUtils.setupToken(IERC20(tokenA), IPositionManager(v4PositionManager), IUniversalRouter(router));
         PoolUtils.setupToken(IERC20(tokenB), IPositionManager(v4PositionManager), IUniversalRouter(router));
-        PoolUtils.deployPool(tokenA, tokenB, IPositionManager(v4PositionManager), IStateView(v4StateView));
+        // PoolUtils.deployPool(tokenA, tokenB, IPositionManager(v4PositionManager), IStateView(v4StateView));
         PoolUtils.deployPool(tokenA, address(0), IPositionManager(v4PositionManager), IStateView(v4StateView));
         PoolUtils.deployPool(tokenB, address(0), IPositionManager(v4PositionManager), IStateView(v4StateView));
 

--- a/packages/veraswap-sdk/src/calls/getBridgeSwapWithKernelCalls.test.ts
+++ b/packages/veraswap-sdk/src/calls/getBridgeSwapWithKernelCalls.test.ts
@@ -24,6 +24,7 @@ import { getKernelAddress } from "../smartaccount/getKernelAddress.js";
 import { getKernelInitData } from "../smartaccount/getKernelInitData.js";
 import { installOwnableExecutor } from "../smartaccount/OwnableExecutor.js";
 import { MOCK_MAILBOX_CONTRACTS, MOCK_MAILBOX_TOKENS } from "../test/constants.js";
+import { poolKeysToPath } from "../types/PoolKey.js";
 import { processNextInboundMessage } from "../utils/MockMailbox.js";
 
 import { getBridgeSwapWithKernelCalls } from "./getBridgeSwapWithKernelCalls.js";
@@ -182,6 +183,11 @@ describe("calls/getBridgeSwapWithKernelCalls.test.ts", function () {
 
             const amount = parseEther("1");
 
+            const currencyIn = zeroForOne ? poolKey.currency0 : poolKey.currency1;
+            const currencyOut = zeroForOne ? poolKey.currency1 : poolKey.currency0;
+
+            const path = poolKeysToPath(currencyIn, [poolKey]);
+
             // Bridge Swap => opChainA -> opChainL1
             const bridgeSwapCalls = await getBridgeSwapWithKernelCalls(queryClient, config, {
                 chainId: opChainL1.id, //"opChainA" but we use are mocking on L1 for now
@@ -217,10 +223,11 @@ describe("calls/getBridgeSwapWithKernelCalls.test.ts", function () {
                     // Adjust amount in if using orbiter to account for fees
                     amountIn: amount,
                     amountOutMinimum,
-                    poolKey,
+                    currencyIn,
+                    currencyOut,
+                    path,
                     receiver: recipient,
                     universalRouter: LOCAL_UNISWAP_CONTRACTS.universalRouter,
-                    zeroForOne,
                 },
             });
             expect(bridgeSwapCalls.calls.length).toBe(1);

--- a/packages/veraswap-sdk/src/calls/getBridgeSwapWithKernelCalls.ts
+++ b/packages/veraswap-sdk/src/calls/getBridgeSwapWithKernelCalls.ts
@@ -1,5 +1,4 @@
 import { QueryClient } from "@tanstack/react-query";
-import { PoolKey } from "@uniswap/v4-sdk";
 import { Config } from "@wagmi/core";
 import { readContractQueryOptions } from "@wagmi/core/query";
 import { getExecMode } from "@zerodev/sdk";
@@ -14,6 +13,7 @@ import { getOrbiterETHTransferTransaction } from "../orbiter/getOrbiterETHTransf
 import { ERC7579ExecutionMode, ERC7579RouterBaseMessage } from "../smartaccount/ERC7579ExecutorRouter.js";
 import { CallArgs, encodeCallArgsBatch } from "../smartaccount/ExecLib.js";
 import { getSwapCalls, GetSwapCallsParams } from "../swap/getSwapCalls.js";
+import { PathKey } from "../types/PoolKey.js";
 import { TokenStandard } from "../types/Token.js";
 
 import { GetCallsReturnType } from "./getCalls.js";
@@ -55,8 +55,9 @@ export interface GetBridgeSwapWithKernelCallsParams extends GetTransferRemoteWit
     remoteSwapParams: {
         amountIn: bigint;
         amountOutMinimum: bigint;
-        zeroForOne: boolean;
-        poolKey: PoolKey;
+        path: PathKey[];
+        currencyIn: Address;
+        currencyOut: Address;
         universalRouter: Address;
         receiver: Address;
         callTargetAfter?: [Address, bigint, Hex];

--- a/packages/veraswap-sdk/src/constants/uniswap.ts
+++ b/packages/veraswap-sdk/src/constants/uniswap.ts
@@ -99,12 +99,12 @@ export const LOCAL_UNISWAP_CONTRACTS = getUniswapContracts();
 export const UNISWAP_CONTRACTS: Record<
     number,
     | {
-        v4PoolManager: `0x${string}`;
-        v4PositionManager: `0x${string}`;
-        v4StateView: `0x${string}`;
-        v4Quoter: `0x${string}`;
-        universalRouter: `0x${string}`;
-    }
+          v4PoolManager: `0x${string}`;
+          v4PositionManager: `0x${string}`;
+          v4StateView: `0x${string}`;
+          v4Quoter: `0x${string}`;
+          universalRouter: `0x${string}`;
+      }
     | undefined
 > = {
     [opChainL1.id]: LOCAL_UNISWAP_CONTRACTS,

--- a/packages/veraswap-sdk/src/constants/uniswap.ts
+++ b/packages/veraswap-sdk/src/constants/uniswap.ts
@@ -99,12 +99,12 @@ export const LOCAL_UNISWAP_CONTRACTS = getUniswapContracts();
 export const UNISWAP_CONTRACTS: Record<
     number,
     | {
-          v4PoolManager: `0x${string}`;
-          v4PositionManager: `0x${string}`;
-          v4StateView: `0x${string}`;
-          v4Quoter: `0x${string}`;
-          universalRouter: `0x${string}`;
-      }
+        v4PoolManager: `0x${string}`;
+        v4PositionManager: `0x${string}`;
+        v4StateView: `0x${string}`;
+        v4Quoter: `0x${string}`;
+        universalRouter: `0x${string}`;
+    }
     | undefined
 > = {
     [opChainL1.id]: LOCAL_UNISWAP_CONTRACTS,

--- a/packages/veraswap-sdk/src/index.test.ts
+++ b/packages/veraswap-sdk/src/index.test.ts
@@ -40,7 +40,7 @@ import { UNISWAP_CONTRACTS } from "./constants/uniswap.js";
 import { getEOASwapCalls } from "./swap/getEOASwapCalls.js";
 import { getPermitTransferFromData } from "./swap/getPermitTransferFromData.js";
 import { getSmartAccountSwapCalls } from "./swap/getSmartAccountSwapCalls.js";
-import { PoolKey, PoolKeyAbi } from "./types/PoolKey.js";
+import { PoolKey, PoolKeyAbi, poolKeysToPath } from "./types/PoolKey.js";
 
 describe("index.test.ts", function () {
     const chain = opChainL1;
@@ -319,12 +319,14 @@ describe("index.test.ts", function () {
             const approvePermit2 = permit2Allowance < amountIn;
 
             const amountOutMinimum = amountOutQuoted;
-            const zeroForOne = true;
+
+            const path = poolKeysToPath(currency0Address, [poolKey]);
             const swapCalls = getEOASwapCalls({
                 amountIn,
                 amountOutMinimum,
-                poolKey,
-                zeroForOne,
+                currencyIn: currency0Address,
+                currencyOut: currency1Address,
+                path,
                 universalRouter: uniswapContracts.universalRouter,
                 approvePermit2,
             });
@@ -421,13 +423,16 @@ describe("index.test.ts", function () {
             const approvePermit2 = permit2Allowance < amountIn;
 
             const amountOutMinimum = amountOutQuoted;
-            const zeroForOne = true;
+
+            const path = poolKeysToPath(currency0Address, [poolKey]);
+
             const batchCalls = getSmartAccountSwapCalls({
                 amountIn,
                 amountOutMinimum,
-                zeroForOne,
+                currencyIn: currency0Address,
+                currencyOut: poolKey.currency1,
+                path,
                 permitTransferFromData,
-                poolKey,
                 universalRouter: uniswapContracts.universalRouter,
                 approvePermit2,
             });

--- a/packages/veraswap-sdk/src/swap/getEOASwapCalls.ts
+++ b/packages/veraswap-sdk/src/swap/getEOASwapCalls.ts
@@ -1,30 +1,30 @@
 import { PERMIT2_ADDRESS } from "@uniswap/permit2-sdk";
-import { PoolKey } from "@uniswap/v4-sdk";
 import { Address, encodeFunctionData, Hex } from "viem";
 
 import { IAllowanceTransfer } from "../artifacts/IAllowanceTransfer.js";
 import { IERC20 } from "../artifacts/IERC20.js";
 import { MAX_UINT_160, MAX_UINT_256, MAX_UINT_48 } from "../constants/index.js";
+import { PathKey } from "../types/PoolKey.js";
 
 import { getSwapExactInExecuteData } from "./getSwapExactInExecuteData.js";
 
 export function getEOASwapCalls({
     amountIn,
     amountOutMinimum,
-    zeroForOne,
-    poolKey,
+    currencyIn,
+    currencyOut,
+    path,
     universalRouter,
     approvePermit2 = true,
 }: {
     amountIn: bigint;
     amountOutMinimum: bigint;
-    zeroForOne: boolean;
-    poolKey: PoolKey;
+    currencyIn: Address;
+    currencyOut: Address;
+    path: PathKey[];
     universalRouter: Address;
     approvePermit2?: boolean;
 }): { to: Address; data: Hex; value: bigint }[] {
-    const currencyIn = (zeroForOne ? poolKey.currency0 : poolKey.currency1) as Address;
-
     /** *** Permit2 Approve universalRouter *****/
     // approve Permit2 to spend Token A
     const approvePermit2Data = {
@@ -50,8 +50,9 @@ export function getEOASwapCalls({
 
     const routerExecuteData = getSwapExactInExecuteData({
         universalRouter,
-        poolKey,
-        zeroForOne,
+        currencyIn,
+        currencyOut,
+        path,
         amountIn,
         amountOutMinimum,
     });

--- a/packages/veraswap-sdk/src/swap/getSmartAccountSwapCalls.ts
+++ b/packages/veraswap-sdk/src/swap/getSmartAccountSwapCalls.ts
@@ -1,33 +1,34 @@
 import { PERMIT2_ADDRESS } from "@uniswap/permit2-sdk";
-import { PoolKey } from "@uniswap/v4-sdk";
 import { Address, encodeFunctionData, Hex } from "viem";
 
 import { IAllowanceTransfer } from "../artifacts/IAllowanceTransfer.js";
 import { IERC20 } from "../artifacts/IERC20.js";
 import { MAX_UINT_160, MAX_UINT_256, MAX_UINT_48 } from "../constants/index.js";
 import { PermitTransferFromData } from "../types/PermitTransferFromData.js";
+import { PathKey } from "../types/PoolKey.js";
 
 import { getSwapExactInExecuteData } from "./getSwapExactInExecuteData.js";
 
 export function getSmartAccountSwapCalls({
     amountIn,
     amountOutMinimum,
-    zeroForOne,
     permitTransferFromData,
-    poolKey,
+    currencyIn,
+    currencyOut,
+    path,
     universalRouter,
     approvePermit2 = true,
 }: {
     amountIn: bigint;
     amountOutMinimum: bigint;
-    zeroForOne: boolean;
+
     permitTransferFromData: PermitTransferFromData;
-    poolKey: PoolKey;
+    currencyIn: Address;
+    currencyOut: Address;
+    path: PathKey[];
     universalRouter: Address;
     approvePermit2?: boolean;
 }): { to: Address; data: Hex; value: bigint }[] {
-    const currencyIn = (zeroForOne ? poolKey.currency0 : poolKey.currency1) as Address;
-
     const permitTransferFromDataFormatted = {
         to: permitTransferFromData.dest,
         data: permitTransferFromData.func,
@@ -59,8 +60,9 @@ export function getSmartAccountSwapCalls({
 
     const routerExecuteData = getSwapExactInExecuteData({
         universalRouter,
-        poolKey,
-        zeroForOne,
+        currencyIn,
+        currencyOut,
+        path,
         amountIn,
         amountOutMinimum,
     });

--- a/packages/veraswap-sdk/src/swap/getSwapAndHyperlaneBridgeTransaction.ts
+++ b/packages/veraswap-sdk/src/swap/getSwapAndHyperlaneBridgeTransaction.ts
@@ -3,7 +3,7 @@ import { Address, encodeFunctionData, Hex, padHex, zeroAddress } from "viem";
 import { HypERC20FlashCollateral } from "../artifacts/HypERC20FlashCollateral.js";
 import { IUniversalRouter } from "../artifacts/IUniversalRouter.js";
 import { PermitSingle } from "../types/AllowanceTransfer.js";
-import { PoolKey } from "../types/PoolKey.js";
+import { PathKey } from "../types/PoolKey.js";
 import { CommandType, RoutePlanner } from "../uniswap/routerCommands.js";
 
 import { getV4SwapCommandParams } from "./getV4SwapCommandParams.js";
@@ -19,8 +19,9 @@ export function getSwapAndHyperlaneBridgeTransaction({
     receiver,
     amountIn,
     amountOutMinimum,
-    poolKey,
-    zeroForOne,
+    currencyIn,
+    currencyOut,
+    path,
     permit2PermitParams,
     hookData = "0x",
 }: {
@@ -31,8 +32,9 @@ export function getSwapAndHyperlaneBridgeTransaction({
     receiver: Address;
     amountIn: bigint;
     amountOutMinimum: bigint;
-    poolKey: PoolKey;
-    zeroForOne: boolean;
+    currencyIn: Address;
+    currencyOut: Address;
+    path: PathKey[];
     permit2PermitParams?: [PermitSingle, Hex];
     hookData?: Hex;
 }) {
@@ -52,8 +54,9 @@ export function getSwapAndHyperlaneBridgeTransaction({
         receiver: bridgeAddress,
         amountIn,
         amountOutMinimum,
-        poolKey,
-        zeroForOne,
+        currencyIn,
+        currencyOut,
+        path,
         hookData,
     });
     routePlanner.addCommand(CommandType.V4_SWAP, [v4SwapParams]);
@@ -70,7 +73,6 @@ export function getSwapAndHyperlaneBridgeTransaction({
 
     const routerDeadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
 
-    const currencyIn = zeroForOne ? poolKey.currency0 : poolKey.currency1;
     const isNative = currencyIn === zeroAddress;
 
     return {

--- a/packages/veraswap-sdk/src/swap/getSwapAndHyperlaneSweepBridgeTransaction.ts
+++ b/packages/veraswap-sdk/src/swap/getSwapAndHyperlaneSweepBridgeTransaction.ts
@@ -3,7 +3,7 @@ import { Address, encodeFunctionData, Hex, zeroAddress } from "viem";
 import { IUniversalRouter } from "../artifacts/IUniversalRouter.js";
 import { HYPERLANE_ROUTER_SWEEP_ADDRESS } from "../constants/index.js";
 import { PermitSingle } from "../types/AllowanceTransfer.js";
-import { PoolKey } from "../types/PoolKey.js";
+import { PathKey } from "../types/PoolKey.js";
 import { CommandType, RoutePlanner } from "../uniswap/routerCommands.js";
 
 import { getHyperlaneSweepBridgeCallTargetParams } from "./getHyperlaneSweepBridgeCallTargetParams.js";
@@ -20,8 +20,9 @@ export function getSwapAndHyperlaneSweepBridgeTransaction({
     receiver,
     amountIn,
     amountOutMinimum,
-    poolKey,
-    zeroForOne,
+    currencyIn,
+    currencyOut,
+    path,
     permit2PermitParams,
     hookData = "0x",
 }: {
@@ -32,8 +33,9 @@ export function getSwapAndHyperlaneSweepBridgeTransaction({
     receiver: Address;
     amountIn: bigint;
     amountOutMinimum: bigint;
-    poolKey: PoolKey;
-    zeroForOne: boolean;
+    currencyIn: Address;
+    currencyOut: Address;
+    path: PathKey[];
     permit2PermitParams?: [PermitSingle, Hex];
     hookData?: Hex;
 }) {
@@ -47,8 +49,9 @@ export function getSwapAndHyperlaneSweepBridgeTransaction({
         receiver: HYPERLANE_ROUTER_SWEEP_ADDRESS,
         amountIn,
         amountOutMinimum,
-        poolKey,
-        zeroForOne,
+        currencyIn,
+        currencyOut,
+        path,
         hookData,
     });
     routePlanner.addCommand(CommandType.V4_SWAP, [v4SwapParams]);
@@ -60,7 +63,6 @@ export function getSwapAndHyperlaneSweepBridgeTransaction({
 
     const routerDeadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
 
-    const currencyIn = zeroForOne ? poolKey.currency0 : poolKey.currency1;
     const isNative = currencyIn === zeroAddress;
 
     return {

--- a/packages/veraswap-sdk/src/swap/getSwapCalls.ts
+++ b/packages/veraswap-sdk/src/swap/getSwapCalls.ts
@@ -1,5 +1,4 @@
 import { QueryClient } from "@tanstack/react-query";
-import { PoolKey } from "@uniswap/v4-sdk";
 import { Config } from "@wagmi/core";
 import { Address, encodeFunctionData, Hex, zeroAddress } from "viem";
 
@@ -7,6 +6,7 @@ import { IUniversalRouter } from "../artifacts/IUniversalRouter.js";
 import { GetCallsParams, GetCallsReturnType } from "../calls/getCalls.js";
 import { getPermit2ApproveCalls } from "../calls/Permit2/getPermit2ApproveCalls.js";
 import { CallArgs } from "../smartaccount/ExecLib.js";
+import { PathKey } from "../types/PoolKey.js";
 import { CommandType, RoutePlanner } from "../uniswap/routerCommands.js";
 
 import { getV4SwapCommandParams } from "./getV4SwapCommandParams.js";
@@ -14,8 +14,9 @@ import { getV4SwapCommandParams } from "./getV4SwapCommandParams.js";
 export interface GetSwapCallsParams extends GetCallsParams {
     amountIn: bigint;
     amountOutMinimum: bigint;
-    zeroForOne: boolean;
-    poolKey: PoolKey;
+    currencyIn: Address;
+    currencyOut: Address;
+    path: PathKey[];
     universalRouter: Address;
     receiver: Address;
     callTargetBefore?: [Address, bigint, Hex];
@@ -35,18 +36,17 @@ export async function getSwapCalls(
         account,
         amountIn,
         amountOutMinimum,
-        poolKey,
+        path,
+        currencyIn,
+        currencyOut,
         universalRouter,
         receiver,
-        zeroForOne,
         callTargetBefore,
         callTargetAfter,
         hookData,
         approveExpiration,
     } = params;
     const routerPayment = params.routerPayment ?? 0n;
-
-    const currencyIn = (zeroForOne ? poolKey.currency0 : poolKey.currency1) as Address;
 
     const calls: (CallArgs & { account: Address })[] = [];
 
@@ -70,8 +70,9 @@ export async function getSwapCalls(
         receiver,
         amountIn,
         amountOutMinimum,
-        poolKey,
-        zeroForOne,
+        path,
+        currencyIn,
+        currencyOut,
         hookData,
     });
     routePlanner.addCommand(CommandType.V4_SWAP, [v4SwapParams]);

--- a/packages/veraswap-sdk/src/swap/getTransaction.ts
+++ b/packages/veraswap-sdk/src/swap/getTransaction.ts
@@ -17,7 +17,6 @@ import { getOrbiterETHTransferTransaction } from "../orbiter/getOrbiterETHTransf
 import { getSuperchainBridgeTransaction } from "../superchain/getSuperchainBridgeTransaction.js";
 import { PermitSingle } from "../types/AllowanceTransfer.js";
 import { OrbiterParams } from "../types/OrbiterParams.js";
-import { poolKeysToPath } from "../types/PoolKey.js";
 import { TokenStandard } from "../types/Token.js";
 import {
     TransactionTypeBridge,
@@ -132,7 +131,7 @@ export async function getTransaction(
             const {
                 currencyIn,
                 currencyOut,
-                route,
+                path,
                 amountIn,
                 walletAddress,
                 amountOutMinimum,
@@ -160,9 +159,6 @@ export async function getTransaction(
                 );
                 permit2PermitParams = permitSingle && signature ? [permitSingle, signature] : undefined;
             }
-
-            // TODO: do the conversion inside of getTransactionType
-            const path = poolKeysToPath(getUniswapV4Address(currencyIn), route);
 
             return getSwapExactInExecuteData({
                 universalRouter: contracts[currencyIn.chainId].universalRouter,
@@ -257,11 +253,8 @@ export async function getTransaction(
                 queryClient,
                 wagmiConfig,
             } = params;
-            const { currencyIn: swapCurrencyIn, route, currencyOut: swapCurrencyOut } = swap;
+            const { currencyIn: swapCurrencyIn, path, currencyOut: swapCurrencyOut } = swap;
             const { currencyIn: bridgeCurrencyIn, currencyOut: bridgeCurrencyOut } = bridge;
-
-            // TODO: do the conversion inside of getTransactionType
-            const path = poolKeysToPath(getUniswapV4Address(swapCurrencyIn), route);
 
             const bridgeAddress = isMultichainToken(bridgeCurrencyIn)
                 ? (bridgeCurrencyIn.hyperlaneAddress ?? bridgeCurrencyIn.address)
@@ -297,7 +290,6 @@ export async function getTransaction(
                 permit2PermitParams = permitSingle && signature ? [permitSingle, signature] : undefined;
             }
 
-            // TODO: figure out why we have MockSuperchainERC20 here
             if (isSuperOrLinkedToSuper(bridgeCurrencyIn) && isSuperOrLinkedToSuper(bridgeCurrencyOut)) {
                 return getSwapAndSuperchainBridgeTransaction({
                     amountIn,
@@ -344,14 +336,11 @@ export async function getTransaction(
             } = params;
             // TODO: check if withSuperchain is needed
             const { currencyIn, currencyOut } = bridge;
-            const { currencyIn: swapCurrencyIn, currencyOut: swapCurrencyOut, route } = swap;
+            const { currencyIn: swapCurrencyIn, currencyOut: swapCurrencyOut, path } = swap;
 
             if (currencyIn.isNative && (!orbiterParams || !orbiterAmountOut)) {
                 throw new Error("Orbiter params and amount out are required for Orbiter bridging");
             }
-
-            // TODO: do the conversion inside of getTransactionType
-            const path = poolKeysToPath(getUniswapV4Address(swapCurrencyIn), route);
 
             // TODO: fix this for non local env
             const originERC7579ExecutorRouter = contracts[currencyIn.chainId].erc7579Router;

--- a/packages/veraswap-sdk/src/swap/getV4SwapCommandParams.ts
+++ b/packages/veraswap-sdk/src/swap/getV4SwapCommandParams.ts
@@ -33,7 +33,7 @@ export function getV4SwapCommandParams({
             { poolKey, zeroForOne, amountIn, amountOutMinimum, hookData },
         ]);
     } else {
-        tradePlan.addAction(Actions.SWAP_EXACT_IN, [currencyIn, path, amountIn, amountOutMinimum]);
+        tradePlan.addAction(Actions.SWAP_EXACT_IN, [{ currencyIn, path, amountIn, amountOutMinimum }]);
     }
 
     tradePlan.addAction(Actions.SETTLE_ALL, [currencyIn, amountIn]);

--- a/packages/veraswap-sdk/src/types/PoolKey.ts
+++ b/packages/veraswap-sdk/src/types/PoolKey.ts
@@ -1,4 +1,5 @@
-import { Address, encodeAbiParameters, keccak256, zeroAddress } from "viem";
+import invariant from "tiny-invariant";
+import { Address, encodeAbiParameters, Hash, Hex, keccak256, zeroAddress } from "viem";
 
 export interface PoolKey {
     currency0: Address;
@@ -20,8 +21,12 @@ export const PoolKeyAbi = {
     type: "tuple",
 } as const;
 
-export function getPoolId(poolKey: PoolKey) {
-    return keccak256(encodeAbiParameters([PoolKeyAbi], [poolKey]));
+export function getPoolKeyEncoding(poolKey: PoolKey): Hex {
+    return encodeAbiParameters([PoolKeyAbi], [poolKey]);
+}
+
+export function getPoolId(poolKey: PoolKey): Hash {
+    return keccak256(getPoolKeyEncoding(poolKey));
 }
 
 export interface PoolKeyOptions {
@@ -58,9 +63,58 @@ export const DEFAULT_POOL_PARAMS = {
  * @param poolKey
  */
 export function createPoolKey(poolKey: PoolKey): PoolKey {
+    invariant(poolKey.currency0 != poolKey.currency1, "PoolKey currency0 == currency1 !");
     return {
         ...poolKey,
         currency0: poolKey.currency0 < poolKey.currency1 ? poolKey.currency0 : poolKey.currency1,
         currency1: poolKey.currency0 < poolKey.currency1 ? poolKey.currency1 : poolKey.currency0,
     };
+}
+
+export function poolKeyEqual(a: PoolKey, b: PoolKey): boolean {
+    return (
+        a.currency0 === b.currency0 &&
+        a.currency1 === b.currency1 &&
+        a.fee === b.fee &&
+        a.tickSpacing === b.tickSpacing &&
+        a.hooks === b.hooks
+    );
+}
+
+/**
+ * Path Key for multihop quoting
+ */
+export interface PathKey {
+    intermediateCurrency: Address;
+    fee: number;
+    tickSpacing: number;
+    hooks: Address;
+    hookData: Hex;
+}
+
+/**
+ * Convert list of pool keys to a path for multihop quoting
+ * @param exactCurrency
+ * @param poolKeys
+ */
+export function poolKeysToPath(exactCurrency: Address, poolKeys: PoolKey[]): PathKey[] {
+    const path: PathKey[] = [];
+
+    let currentCurrency = exactCurrency;
+
+    poolKeys.forEach((poolKey) => {
+        // Intermediate currency is whichever isn't current
+        const intermediateCurrency = poolKey.currency0 != currentCurrency ? poolKey.currency0 : poolKey.currency1;
+        path.push({
+            intermediateCurrency,
+            fee: poolKey.fee,
+            tickSpacing: poolKey.tickSpacing,
+            hooks: poolKey.hooks,
+            hookData: "0x",
+        });
+        // Update currentCurrency
+        currentCurrency = intermediateCurrency;
+    });
+
+    return path;
 }

--- a/packages/veraswap-sdk/src/types/PoolKey.ts
+++ b/packages/veraswap-sdk/src/types/PoolKey.ts
@@ -24,6 +24,12 @@ export function getPoolId(poolKey: PoolKey) {
     return keccak256(encodeAbiParameters([PoolKeyAbi], [poolKey]));
 }
 
+export interface PoolKeyOptions {
+    fee: number;
+    tickSpacing: number;
+    hooks: Address;
+}
+
 export const DEFAULT_POOL_PARAMS = {
     FEE_100_TICK_1: {
         fee: 100,
@@ -42,10 +48,10 @@ export const DEFAULT_POOL_PARAMS = {
     },
     FEE_10_000_TICK_200: {
         fee: 10_000,
-        tickspacing: 200,
+        tickSpacing: 200,
         hooks: zeroAddress,
     },
-};
+} satisfies Record<string, PoolKeyOptions>;
 
 /**
  * Create pool key with validation

--- a/packages/veraswap-sdk/src/types/PoolKey.ts
+++ b/packages/veraswap-sdk/src/types/PoolKey.ts
@@ -63,7 +63,7 @@ export const DEFAULT_POOL_PARAMS = {
  * @param poolKey
  */
 export function createPoolKey(poolKey: PoolKey): PoolKey {
-    invariant(poolKey.currency0 != poolKey.currency1, "PoolKey currency0 == currency1 !");
+    invariant(poolKey.currency0 != poolKey.currency1, "poolKey currency0 must be != currency1");
     return {
         ...poolKey,
         currency0: poolKey.currency0 < poolKey.currency1 ? poolKey.currency0 : poolKey.currency1,

--- a/packages/veraswap-sdk/src/types/PoolKey.ts
+++ b/packages/veraswap-sdk/src/types/PoolKey.ts
@@ -118,3 +118,16 @@ export function poolKeysToPath(exactCurrency: Address, poolKeys: PoolKey[]): Pat
 
     return path;
 }
+
+/**
+ * Convert a single path key to a pool key
+ */
+export function pathKeyToPoolKey(pathKey: PathKey, currencyIn: Address): PoolKey {
+    return {
+        currency0: currencyIn < pathKey.intermediateCurrency ? currencyIn : pathKey.intermediateCurrency,
+        currency1: currencyIn < pathKey.intermediateCurrency ? pathKey.intermediateCurrency : currencyIn,
+        fee: pathKey.fee,
+        tickSpacing: pathKey.tickSpacing,
+        hooks: pathKey.hooks,
+    };
+}

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.test.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.test.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 import { createConfig, http } from "@wagmi/core";
-import { parseEther, zeroAddress } from "viem";
+import { parseUnits, zeroAddress } from "viem";
 import { describe, expect, test } from "vitest";
 
 import { opChainL1 } from "../chains/supersim.js";
@@ -19,16 +19,17 @@ describe.skip("uniswap/getUniswapV4Route.test.ts", function () {
     });
     const queryClient = new QueryClient();
 
-    const tokenA = getUniswapV4Address(LOCAL_CURRENCIES[0]);
-    const tokenB = getUniswapV4Address(LOCAL_CURRENCIES[3]);
+    const tokenA = LOCAL_CURRENCIES[0];
+    const tokenAAddress = getUniswapV4Address(tokenA);
+    const tokenBAddress = getUniswapV4Address(LOCAL_CURRENCIES[3]);
 
     test("getUniswapV4Route - single hop", async () => {
         const result = await getUniswapV4Route(queryClient, config, {
             chainId: opChainL1.id,
-            currencyIn: tokenA,
+            currencyIn: tokenAAddress,
             currencyOut: zeroAddress,
             currencyHops: [],
-            exactAmount: parseEther("1"),
+            exactAmount: parseUnits("1", tokenA.decimals),
             contracts: {
                 v4StateView: LOCAL_UNISWAP_CONTRACTS.v4StateView,
                 v4Quoter: LOCAL_UNISWAP_CONTRACTS.v4Quoter,
@@ -43,10 +44,10 @@ describe.skip("uniswap/getUniswapV4Route.test.ts", function () {
     test("getUniswapV4Route - multi hop", async () => {
         const result = await getUniswapV4Route(queryClient, config, {
             chainId: opChainL1.id,
-            currencyIn: tokenA,
-            currencyOut: tokenB,
+            currencyIn: tokenAAddress,
+            currencyOut: tokenBAddress,
             currencyHops: [zeroAddress],
-            exactAmount: parseEther("1"),
+            exactAmount: parseUnits("1", tokenA.decimals),
             contracts: {
                 v4StateView: LOCAL_UNISWAP_CONTRACTS.v4StateView,
                 v4Quoter: LOCAL_UNISWAP_CONTRACTS.v4Quoter,

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.test.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.test.ts
@@ -1,0 +1,60 @@
+import { QueryClient } from "@tanstack/react-query";
+import { createConfig, http } from "@wagmi/core";
+import { parseEther, zeroAddress } from "viem";
+import { describe, expect, test } from "vitest";
+
+import { opChainL1 } from "../chains/supersim.js";
+import { LOCAL_CURRENCIES } from "../constants/tokens.js";
+import { LOCAL_UNISWAP_CONTRACTS } from "../constants/uniswap.js";
+import { getUniswapV4Address } from "../currency/currency.js";
+
+import { getUniswapV4Route } from "./getUniswapV4Route.js";
+
+describe("calls/getERC20ApproveCall.test.ts", function () {
+    const config = createConfig({
+        chains: [opChainL1],
+        transports: {
+            [opChainL1.id]: http(),
+        },
+    });
+    const queryClient = new QueryClient();
+
+    const tokenA = getUniswapV4Address(LOCAL_CURRENCIES[0]);
+    const tokenB = getUniswapV4Address(LOCAL_CURRENCIES[3]);
+
+    test("getUniswapV4Route - single hop", async () => {
+        const result = await getUniswapV4Route(queryClient, config, {
+            chainId: opChainL1.id,
+            currencyIn: tokenA,
+            currencyOut: zeroAddress,
+            currencyHops: [],
+            exactAmount: parseEther("1"),
+            contracts: {
+                v4StateView: LOCAL_UNISWAP_CONTRACTS.v4StateView,
+                v4Quoter: LOCAL_UNISWAP_CONTRACTS.v4Quoter,
+            },
+        });
+
+        expect(result).toBeDefined();
+        expect(result.route.length).toBe(1);
+        expect(result.amountOut).toBeGreaterThan(0n);
+    });
+
+    test("getUniswapV4Route - multi hop", async () => {
+        const result = await getUniswapV4Route(queryClient, config, {
+            chainId: opChainL1.id,
+            currencyIn: tokenA,
+            currencyOut: tokenB,
+            currencyHops: [zeroAddress],
+            exactAmount: parseEther("1"),
+            contracts: {
+                v4StateView: LOCAL_UNISWAP_CONTRACTS.v4StateView,
+                v4Quoter: LOCAL_UNISWAP_CONTRACTS.v4Quoter,
+            },
+        });
+
+        expect(result).toBeDefined();
+        expect(result.route.length).toBe(2);
+        expect(result.amountOut).toBeGreaterThan(0n);
+    });
+});

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.test.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.test.ts
@@ -10,7 +10,7 @@ import { getUniswapV4Address } from "../currency/currency.js";
 
 import { getUniswapV4Route } from "./getUniswapV4Route.js";
 
-describe("uniswap/getUniswapV4Route.test.ts", function () {
+describe.skip("uniswap/getUniswapV4Route.test.ts", function () {
     const config = createConfig({
         chains: [opChainL1],
         transports: {

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.test.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.test.ts
@@ -10,7 +10,7 @@ import { getUniswapV4Address } from "../currency/currency.js";
 
 import { getUniswapV4Route } from "./getUniswapV4Route.js";
 
-describe("calls/getERC20ApproveCall.test.ts", function () {
+describe("uniswap/getUniswapV4Route.test.ts", function () {
     const config = createConfig({
         chains: [opChainL1],
         transports: {
@@ -35,9 +35,9 @@ describe("calls/getERC20ApproveCall.test.ts", function () {
             },
         });
 
-        expect(result).toBeDefined();
-        expect(result.route.length).toBe(1);
-        expect(result.amountOut).toBeGreaterThan(0n);
+        expect(result).not.toBe(null);
+        expect(result!.route.length).toBe(1);
+        expect(result!.amountOut).toBeGreaterThan(0n);
     });
 
     test("getUniswapV4Route - multi hop", async () => {
@@ -53,8 +53,8 @@ describe("calls/getERC20ApproveCall.test.ts", function () {
             },
         });
 
-        expect(result).toBeDefined();
-        expect(result.route.length).toBe(2);
-        expect(result.amountOut).toBeGreaterThan(0n);
+        expect(result).not.toBe(null);
+        expect(result!.route.length).toBe(2);
+        expect(result!.amountOut).toBeGreaterThan(0n);
     });
 });

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
@@ -1,9 +1,8 @@
-import { route } from "@owlprotocol/contracts-hyperlane/artifacts/IRoutingIsm";
 import { QueryClient } from "@tanstack/react-query";
 import { Config } from "@wagmi/core";
 import { readContractQueryOptions } from "@wagmi/core/query";
 import { flatten, maxBy, uniqWith, zip } from "lodash-es";
-import { Address } from "viem";
+import { Address, numberToHex } from "viem";
 
 import { IStateView } from "../artifacts/IStateView.js";
 import {
@@ -64,7 +63,7 @@ export async function getUniswapV4Route(
                             {
                                 poolKey,
                                 zeroForOne,
-                                exactAmount,
+                                exactAmount: numberToHex(exactAmount),
                                 hookData: "0x",
                             },
                         ],
@@ -79,7 +78,13 @@ export async function getUniswapV4Route(
                         address: contracts.v4Quoter,
                         abi: [quoteExactInputAbi],
                         functionName: "quoteExactInput",
-                        args: [currencyIn, path, exactAmount],
+                        args: [
+                            {
+                                exactCurrency: currencyIn,
+                                path,
+                                exactAmount: numberToHex(exactAmount),
+                            },
+                        ],
                     }),
                 );
             }
@@ -94,7 +99,8 @@ export async function getUniswapV4Route(
             gasEstimate: quote![1],
         };
     });
-    const bestRoute = maxBy(routesWithQuotes, (r) => r.amountOut);
+    const bestRoute = maxBy(routesWithQuotes, (r) => r.amountOut)!;
+
     return bestRoute;
 }
 

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
@@ -2,7 +2,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { Config } from "@wagmi/core";
 import { readContractQueryOptions } from "@wagmi/core/query";
 import { flatten, maxBy, uniqWith, zip } from "lodash-es";
-import { Address, numberToHex } from "viem";
+import { Address } from "viem";
 
 import { IStateView } from "../artifacts/IStateView.js";
 import {
@@ -137,7 +137,7 @@ export interface GetUniswapV4RouteParams extends GetUniswapV4RoutesWithLiquidity
 }
 
 /**
- * Get best Uniswap V4 Route
+ * GetUniswap V4 Route with best amount out quoted
  * @param queryClient
  * @param wagmiConfig
  * @param params
@@ -169,7 +169,7 @@ export async function getUniswapV4Route(
                             {
                                 poolKey,
                                 zeroForOne,
-                                exactAmount: numberToHex(exactAmount),
+                                exactAmount,
                                 hookData: "0x",
                             },
                         ],
@@ -188,7 +188,7 @@ export async function getUniswapV4Route(
                             {
                                 exactCurrency: currencyIn,
                                 path,
-                                exactAmount: numberToHex(exactAmount),
+                                exactAmount,
                             },
                         ],
                     }),

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
@@ -1,0 +1,14 @@
+import { Address } from "viem";
+
+import { createPoolKey, DEFAULT_POOL_PARAMS, PoolKey, PoolKeyOptions } from "../types/PoolKey.js";
+
+/**
+ * Get all pool keys for 2 tokens & a list of options
+ */
+export function getPoolKeysForOptions(
+    currencyA: Address,
+    currencyB: Address,
+    options: PoolKeyOptions[] = Object.values(DEFAULT_POOL_PARAMS),
+): PoolKey[] {
+    return options.map((option) => createPoolKey({ currency0: currencyA, currency1: currencyB, ...option }));
+}

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
@@ -2,7 +2,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { Config } from "@wagmi/core";
 import { readContractQueryOptions } from "@wagmi/core/query";
 import { flatten, maxBy, uniqWith, zip } from "lodash-es";
-import { Address } from "viem";
+import { Address, numberToHex } from "viem";
 
 import { IStateView } from "../artifacts/IStateView.js";
 import {
@@ -169,7 +169,7 @@ export async function getUniswapV4Route(
                             {
                                 poolKey,
                                 zeroForOne,
-                                exactAmount,
+                                exactAmount: numberToHex(exactAmount),
                                 hookData: "0x",
                             },
                         ],
@@ -188,7 +188,7 @@ export async function getUniswapV4Route(
                             {
                                 exactCurrency: currencyIn,
                                 path,
-                                exactAmount,
+                                exactAmount: numberToHex(exactAmount),
                             },
                         ],
                     }),

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
@@ -32,7 +32,8 @@ export function getPoolKeysForOptions(
 }
 
 /**
- * Return route (list of pool keys) permutations that have [A, ..., B]
+ * Returns trade routes as lists of pool keys that start with currencyIn and output currencyOut
+ * @param currencyHops an array of possible intermediate tokens to swap currencyIn and currencyOut with
  */
 export function getPoolKeyRoutePermutations(
     currencyIn: Address,
@@ -93,8 +94,8 @@ export async function getUniswapV4RoutesWithLiquidity(
     wagmiConfig: Config,
     params: GetUniswapV4RoutesWithLiquidityParams,
 ) {
-    const { chainId, currencyIn, currencyOut, currencyHops, contracts } = params;
-    const routes = getPoolKeyRoutePermutations(currencyIn, currencyOut, currencyHops, params.poolKeyOptions);
+    const { chainId, currencyIn, currencyOut, currencyHops, contracts, poolKeyOptions } = params;
+    const routes = getPoolKeyRoutePermutations(currencyIn, currencyOut, currencyHops, poolKeyOptions);
 
     // Find pools with liquidity
     const poolKeys = uniqWith(flatten(routes), poolKeyEqual);

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
@@ -1,6 +1,197 @@
+import { route } from "@owlprotocol/contracts-hyperlane/artifacts/IRoutingIsm";
+import { QueryClient } from "@tanstack/react-query";
+import { Config } from "@wagmi/core";
+import { readContractQueryOptions } from "@wagmi/core/query";
+import { flatten, maxBy, uniqWith, zip } from "lodash-es";
 import { Address } from "viem";
 
-import { createPoolKey, DEFAULT_POOL_PARAMS, PoolKey, PoolKeyOptions } from "../types/PoolKey.js";
+import { IStateView } from "../artifacts/IStateView.js";
+import {
+    quoteExactInput as quoteExactInputAbi,
+    quoteExactInputSingle as quoteExactInputSingleAbi,
+} from "../artifacts/IV4Quoter.js";
+import {
+    createPoolKey,
+    DEFAULT_POOL_PARAMS,
+    getPoolId,
+    getPoolKeyEncoding,
+    PoolKey,
+    poolKeyEqual,
+    PoolKeyOptions,
+    poolKeysToPath,
+} from "../types/PoolKey.js";
+
+/**
+ * Get best Uniswap V4 Route
+ */
+export interface GetUniswapV4RouteParams extends GetUniswapV4RoutesWithLiquidityParams {
+    exactAmount: bigint;
+    contracts: {
+        v4StateView: Address;
+        v4Quoter: Address;
+    };
+}
+
+/**
+ * Get best Uniswap V4 Route
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ * @returns
+ */
+export async function getUniswapV4Route(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetUniswapV4RouteParams,
+) {
+    const { chainId, exactAmount, currencyIn, currencyOut, contracts } = params;
+    const zeroForOne = currencyIn < currencyOut;
+
+    const routesWithLiquidity = await getUniswapV4RoutesWithLiquidity(queryClient, wagmiConfig, params);
+
+    const routeQuotes = (await Promise.all(
+        routesWithLiquidity.map((route) => {
+            if (route.length == 1) {
+                // Single-hop
+                const poolKey = route[0];
+                return queryClient.fetchQuery(
+                    readContractQueryOptions(wagmiConfig, {
+                        chainId,
+                        address: contracts.v4Quoter,
+                        abi: [quoteExactInputSingleAbi],
+                        functionName: "quoteExactInputSingle",
+                        args: [
+                            {
+                                poolKey,
+                                zeroForOne,
+                                exactAmount,
+                                hookData: "0x",
+                            },
+                        ],
+                    }),
+                );
+            } else {
+                // Multi-hop
+                const path = poolKeysToPath(currencyIn, route);
+                return queryClient.fetchQuery(
+                    readContractQueryOptions(wagmiConfig, {
+                        chainId,
+                        address: contracts.v4Quoter,
+                        abi: [quoteExactInputAbi],
+                        functionName: "quoteExactInput",
+                        args: [currencyIn, path, exactAmount],
+                    }),
+                );
+            }
+        }),
+    )) as [amountOut: bigint, gasEstimate: bigint][];
+
+    const routesWithQuotes = zip(routesWithLiquidity, routeQuotes).map(([route, quote]) => {
+        // TODO: Update amountOut to account for gas?
+        return {
+            route: route!,
+            amountOut: quote![0],
+            gasEstimate: quote![1],
+        };
+    });
+    const bestRoute = maxBy(routesWithQuotes, (r) => r.amountOut);
+    return bestRoute;
+}
+
+/**
+ * Get Uniswap V4 Routes that have active liquidity
+ */
+export interface GetUniswapV4RoutesWithLiquidityParams {
+    chainId: number;
+    currencyIn: Address;
+    currencyOut: Address;
+    currencyHops: Address[];
+    poolKeyOptions?: PoolKeyOptions[];
+    contracts: {
+        v4StateView: Address;
+    };
+}
+
+/**
+ * Get Uniswap V4 Routes that have active liquidity
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ * @returns
+ */
+export async function getUniswapV4RoutesWithLiquidity(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetUniswapV4RoutesWithLiquidityParams,
+) {
+    const { chainId, currencyIn, currencyOut, currencyHops, contracts } = params;
+    const poolKeyOptions: PoolKeyOptions[] = params.poolKeyOptions ?? Object.values(DEFAULT_POOL_PARAMS);
+
+    const routes = getPoolKeyRoutePermutations(currencyIn, currencyOut, currencyHops, poolKeyOptions);
+
+    // Find pools with liquidity
+    const poolKeys = uniqWith(flatten(routes), poolKeyEqual);
+    const poolKeysLiquidity = await Promise.all(
+        poolKeys.map((poolKey) =>
+            queryClient.fetchQuery(
+                readContractQueryOptions(wagmiConfig, {
+                    chainId,
+                    address: contracts.v4StateView,
+                    abi: IStateView.abi,
+                    functionName: "getLiquidity",
+                    args: [getPoolId(poolKey)],
+                }),
+            ),
+        ),
+    );
+    const poolKeysWithLiquidity = new Set(
+        poolKeys.filter((_, idx) => poolKeysLiquidity[idx] > 0n).map((poolKey) => getPoolKeyEncoding(poolKey)),
+    );
+
+    // Filter out routes with no liquidity
+    const routesWithLiquidity = routes.filter((route) => {
+        // All pool keys must have liquidity
+        return route.reduce((acc, poolKey) => acc && poolKeysWithLiquidity.has(getPoolKeyEncoding(poolKey)), true);
+    });
+
+    return routesWithLiquidity;
+}
+
+/**
+ * Return route (list of pool keys) permutations that have [A, ..., B]
+ */
+export function getPoolKeyRoutePermutations(
+    currencyIn: Address,
+    currencyOut: Address,
+    currencyHops: Address[],
+    poolKeyOptions: PoolKeyOptions[] = Object.values(DEFAULT_POOL_PARAMS),
+): PoolKey[][] {
+    // Filter out any duplicates
+    const currencyHopsUniq = currencyHops.filter(
+        (currencyHop) => currencyHop != currencyIn && currencyHop != currencyOut,
+    );
+
+    // In/Out Pools
+    const singleHopRoutes: [PoolKey][] = getPoolKeysForOptions(currencyIn, currencyOut, poolKeyOptions).map(
+        (poolKey) => [poolKey],
+    );
+
+    const multiHopRoutes: [PoolKey, PoolKey][] = [];
+
+    currencyHopsUniq.forEach((currencyHop) => {
+        // In/X Pools
+        const poolKeysIn = getPoolKeysForOptions(currencyIn, currencyHop, poolKeyOptions);
+        // Out/X Pools
+        const poolKeysOut = getPoolKeysForOptions(currencyOut, currencyHop, poolKeyOptions);
+        poolKeysIn.forEach((poolKeyIn) => {
+            poolKeysOut.forEach((poolKeyOut) => {
+                multiHopRoutes.push([poolKeyIn, poolKeyOut]);
+            });
+        });
+    });
+
+    return [...singleHopRoutes, ...multiHopRoutes];
+}
 
 /**
  * Get all pool keys for 2 tokens & a list of options
@@ -8,7 +199,7 @@ import { createPoolKey, DEFAULT_POOL_PARAMS, PoolKey, PoolKeyOptions } from "../
 export function getPoolKeysForOptions(
     currencyA: Address,
     currencyB: Address,
-    options: PoolKeyOptions[] = Object.values(DEFAULT_POOL_PARAMS),
+    poolKeyOptions: PoolKeyOptions[] = Object.values(DEFAULT_POOL_PARAMS),
 ): PoolKey[] {
-    return options.map((option) => createPoolKey({ currency0: currencyA, currency1: currencyB, ...option }));
+    return poolKeyOptions.map((option) => createPoolKey({ currency0: currencyA, currency1: currencyB, ...option }));
 }

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4Route.ts
@@ -112,15 +112,15 @@ export async function getUniswapV4RoutesWithLiquidity(
             ),
         ),
     );
-    const poolKeysWithLiquidity = new Set(
-        poolKeys.filter((_, idx) => poolKeysLiquidity[idx] > 0n).map((poolKey) => getPoolKeyEncoding(poolKey)),
-    );
+
+    const poolKeysWithLiquidity = poolKeys.filter((_, idx) => poolKeysLiquidity[idx] > 0n);
+    const poolKeysWithLiquidityEncoded = new Set(poolKeysWithLiquidity.map((poolKey) => getPoolKeyEncoding(poolKey)));
 
     // Filter out routes with no liquidity
-    const routesWithLiquidity = routes.filter((route) => {
-        // All pool keys must have liquidity
-        return route.reduce((acc, poolKey) => acc && poolKeysWithLiquidity.has(getPoolKeyEncoding(poolKey)), true);
-    });
+    const routesWithLiquidity = routes.filter((route) =>
+        // All pool keys in the route must have liquidity
+        route.every((poolKey) => poolKeysWithLiquidityEncoded.has(getPoolKeyEncoding(poolKey))),
+    );
 
     return routesWithLiquidity;
 }

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.test.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.test.ts
@@ -14,7 +14,7 @@ import {
     RouteComponentSwap,
 } from "./getUniswapV4RouteMultichain.js";
 
-describe("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
+describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
     const config = createConfig({
         chains: [opChainL1],
         transports: {

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.test.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.test.ts
@@ -107,9 +107,11 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
                 currencyHopsByChain,
             });
             expect(result).not.toBe(null);
-            expect(result!.length).toBe(1);
 
-            const bridge = result![0] as RouteComponentBridge;
+            const { flows } = result!;
+            expect(flows.length).toBe(1);
+
+            const bridge = flows[0] as RouteComponentBridge;
             expect(bridge.currencyIn.equals(tokenA_900));
             expect(bridge.currencyOut.equals(tokenA_901));
         });
@@ -125,9 +127,11 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
                 currencyHopsByChain,
             });
             expect(result).not.toBe(null);
-            expect(result!.length).toBe(1);
 
-            const swap = result![0] as RouteComponentSwap;
+            const { flows } = result!;
+            expect(flows.length).toBe(1);
+
+            const swap = flows[0] as RouteComponentSwap;
             expect(swap.route.length).toBe(2);
             expect(swap.amountOut).toBeGreaterThan(0n);
             expect(swap.currencyIn.equals(tokenA_900));
@@ -145,15 +149,17 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
                 currencyHopsByChain,
             });
             expect(result).not.toBe(null);
-            expect(result!.length).toBe(2);
 
-            const swap = result![0] as RouteComponentSwap;
+            const { flows } = result!;
+            expect(flows.length).toBe(2);
+
+            const swap = flows[0] as RouteComponentSwap;
             expect(swap.route.length).toBe(2);
             expect(swap.amountOut).toBeGreaterThan(0n);
             expect(swap.currencyIn.equals(tokenA_900));
             expect(swap.currencyOut.equals(tokenB_900));
 
-            const bridge = result![1] as RouteComponentBridge;
+            const bridge = flows[1] as RouteComponentBridge;
             expect(bridge.currencyIn.equals(tokenB_900));
             expect(bridge.currencyOut.equals(tokenA_901));
         });
@@ -169,13 +175,15 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
                 currencyHopsByChain,
             });
             expect(result).not.toBe(null);
-            expect(result!.length).toBe(2);
 
-            const bridge = result![0] as RouteComponentBridge;
+            const { flows } = result!;
+            expect(flows.length).toBe(2);
+
+            const bridge = flows[0] as RouteComponentBridge;
             expect(bridge.currencyIn.equals(tokenA_901));
             expect(bridge.currencyOut.equals(tokenA_900));
 
-            const swap = result![1] as RouteComponentSwap;
+            const swap = flows[1] as RouteComponentSwap;
             expect(swap.route.length).toBe(2);
             expect(swap.amountOut).toBeGreaterThan(0n);
             expect(swap.currencyIn.equals(tokenA_900));
@@ -193,19 +201,21 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
                 currencyHopsByChain,
             });
             expect(result).not.toBe(null);
-            expect(result!.length).toBe(3);
 
-            const bridgeIn = result![0] as RouteComponentBridge;
+            const { flows } = result!;
+            expect(flows.length).toBe(3);
+
+            const bridgeIn = flows[0] as RouteComponentBridge;
             expect(bridgeIn.currencyIn.equals(tokenA_901));
             expect(bridgeIn.currencyOut.equals(tokenA_900));
 
-            const swap = result![1] as RouteComponentSwap;
+            const swap = flows[1] as RouteComponentSwap;
             expect(swap.route.length).toBe(2);
             expect(swap.amountOut).toBeGreaterThan(0n);
             expect(swap.currencyIn.equals(tokenA_900));
             expect(swap.currencyOut.equals(tokenB_900));
 
-            const bridgeOut = result![2] as RouteComponentBridge;
+            const bridgeOut = flows[2] as RouteComponentBridge;
             expect(bridgeOut.currencyIn.equals(tokenB_900));
             expect(bridgeOut.currencyOut.equals(tokenB_902));
         });

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.test.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.test.ts
@@ -1,0 +1,213 @@
+import { QueryClient } from "@tanstack/react-query";
+import { createConfig, http } from "@wagmi/core";
+import { parseEther, zeroAddress } from "viem";
+import { describe, expect, test } from "vitest";
+
+import { opChainA, opChainB, opChainL1 } from "../chains/supersim.js";
+import { LOCAL_CURRENCIES } from "../constants/tokens.js";
+import { LOCAL_UNISWAP_CONTRACTS } from "../constants/uniswap.js";
+
+import {
+    getRouteMultichain,
+    getUniswapV4RouteMultichain,
+    RouteComponentBridge,
+    RouteComponentSwap,
+} from "./getUniswapV4RouteMultichain.js";
+
+describe("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
+    const config = createConfig({
+        chains: [opChainL1],
+        transports: {
+            [opChainL1.id]: http(),
+            [opChainA.id]: http(),
+            [opChainB.id]: http(),
+        },
+    });
+    const queryClient = new QueryClient();
+
+    const tokenA_900 = LOCAL_CURRENCIES[0];
+    const tokenA_901 = LOCAL_CURRENCIES[1];
+    // const tokenA_902 = LOCAL_CURRENCIES[2];
+    const tokenB_900 = LOCAL_CURRENCIES[3];
+    const tokenB_901 = LOCAL_CURRENCIES[4];
+    const tokenB_902 = LOCAL_CURRENCIES[5];
+
+    const contractsByChain = {
+        [opChainL1.id]: {
+            v4StateView: LOCAL_UNISWAP_CONTRACTS.v4StateView,
+            v4Quoter: LOCAL_UNISWAP_CONTRACTS.v4Quoter,
+        },
+    };
+    const currencyHopsByChain = {
+        [opChainL1.id]: [zeroAddress],
+    };
+
+    describe("getUniswapV4RouteMultichain", () => {
+        test("same chain, with liquidity", async () => {
+            // Tokens are on the same chain (900)
+            // Liquidity is on different chain (900)
+            const result = await getUniswapV4RouteMultichain(queryClient, config, {
+                currencyIn: tokenA_900,
+                currencyOut: tokenB_900,
+                exactAmount: parseEther("1"),
+                contractsByChain,
+                currencyHopsByChain,
+            });
+            expect(result).not.toBe(null);
+            expect(result!.route.length).toBe(2);
+            expect(result!.amountOut).toBeGreaterThan(0n);
+            expect(result!.currencyIn.equals(tokenA_900));
+            expect(result!.currencyOut.equals(tokenB_900));
+        });
+
+        test("same chain, no liquidity", async () => {
+            // Tokens are on same chain (901)
+            // Liquidity is on different chain (900)
+            const result = await getUniswapV4RouteMultichain(queryClient, config, {
+                currencyIn: tokenA_901,
+                currencyOut: tokenB_901,
+                exactAmount: parseEther("1"),
+                contractsByChain,
+                currencyHopsByChain,
+            });
+            expect(result).not.toBe(null);
+            expect(result!.route.length).toBe(2);
+            expect(result!.amountOut).toBeGreaterThan(0n);
+            expect(result!.currencyIn.equals(tokenA_900));
+            expect(result!.currencyOut.equals(tokenB_900));
+        });
+
+        test("different chains", async () => {
+            // Tokens are on different chains (901, 902)
+            // Liquidity is on a third different chain (900)
+            const result = await getUniswapV4RouteMultichain(queryClient, config, {
+                currencyIn: tokenA_901,
+                currencyOut: tokenB_902,
+                exactAmount: parseEther("1"),
+                contractsByChain,
+                currencyHopsByChain,
+            });
+            expect(result).not.toBe(null);
+            expect(result!.route.length).toBe(2);
+            expect(result!.amountOut).toBeGreaterThan(0n);
+            expect(result!.currencyIn.equals(tokenA_900));
+            expect(result!.currencyOut.equals(tokenB_900));
+        });
+    });
+
+    describe("getRouteMultichain", () => {
+        test("BRIDGE: different chain", async () => {
+            // Tokens are on the different chains (900, 901)
+            // No swap needed
+            const result = await getRouteMultichain(queryClient, config, {
+                currencyIn: tokenA_900,
+                currencyOut: tokenA_901,
+                exactAmount: parseEther("1"),
+                contractsByChain,
+                currencyHopsByChain,
+            });
+            expect(result).not.toBe(null);
+            expect(result!.length).toBe(1);
+
+            const bridge = result![0] as RouteComponentBridge;
+            expect(bridge.currencyIn.equals(tokenA_900));
+            expect(bridge.currencyOut.equals(tokenA_901));
+        });
+
+        test("SWAP: same chain, with liquidity", async () => {
+            // Tokens are on the same chain (900)
+            // Liquidity is on same chain (900)
+            const result = await getRouteMultichain(queryClient, config, {
+                currencyIn: tokenA_900,
+                currencyOut: tokenB_900,
+                exactAmount: parseEther("1"),
+                contractsByChain,
+                currencyHopsByChain,
+            });
+            expect(result).not.toBe(null);
+            expect(result!.length).toBe(1);
+
+            const swap = result![0] as RouteComponentSwap;
+            expect(swap.route.length).toBe(2);
+            expect(swap.amountOut).toBeGreaterThan(0n);
+            expect(swap.currencyIn.equals(tokenA_900));
+            expect(swap.currencyOut.equals(tokenB_900));
+        });
+
+        test("SWAP_BRIDGE: different chain, input liquidity", async () => {
+            // Tokens are on different chains (900, 901)
+            // Liquidity is on input chain (900)
+            const result = await getRouteMultichain(queryClient, config, {
+                currencyIn: tokenA_900,
+                currencyOut: tokenB_901,
+                exactAmount: parseEther("1"),
+                contractsByChain,
+                currencyHopsByChain,
+            });
+            expect(result).not.toBe(null);
+            expect(result!.length).toBe(2);
+
+            const swap = result![0] as RouteComponentSwap;
+            expect(swap.route.length).toBe(2);
+            expect(swap.amountOut).toBeGreaterThan(0n);
+            expect(swap.currencyIn.equals(tokenA_900));
+            expect(swap.currencyOut.equals(tokenB_900));
+
+            const bridge = result![1] as RouteComponentBridge;
+            expect(bridge.currencyIn.equals(tokenB_900));
+            expect(bridge.currencyOut.equals(tokenA_901));
+        });
+
+        test("BRIDGE_SWAP: different chain, output liquidity", async () => {
+            // Tokens are on different chains (901, 900)
+            // Liquidity is on output chain (900)
+            const result = await getRouteMultichain(queryClient, config, {
+                currencyIn: tokenA_901,
+                currencyOut: tokenB_900,
+                exactAmount: parseEther("1"),
+                contractsByChain,
+                currencyHopsByChain,
+            });
+            expect(result).not.toBe(null);
+            expect(result!.length).toBe(2);
+
+            const bridge = result![0] as RouteComponentBridge;
+            expect(bridge.currencyIn.equals(tokenA_901));
+            expect(bridge.currencyOut.equals(tokenA_900));
+
+            const swap = result![1] as RouteComponentSwap;
+            expect(swap.route.length).toBe(2);
+            expect(swap.amountOut).toBeGreaterThan(0n);
+            expect(swap.currencyIn.equals(tokenA_900));
+            expect(swap.currencyOut.equals(tokenB_900));
+        });
+
+        test("BRIDGE_SWAP_BRIDGE: different chain, output liquidity", async () => {
+            // Tokens are on different chains (901, 902)
+            // Liquidity is on a third different chain (900)
+            const result = await getRouteMultichain(queryClient, config, {
+                currencyIn: tokenA_901,
+                currencyOut: tokenB_902,
+                exactAmount: parseEther("1"),
+                contractsByChain,
+                currencyHopsByChain,
+            });
+            expect(result).not.toBe(null);
+            expect(result!.length).toBe(3);
+
+            const bridgeIn = result![0] as RouteComponentBridge;
+            expect(bridgeIn.currencyIn.equals(tokenA_901));
+            expect(bridgeIn.currencyOut.equals(tokenA_900));
+
+            const swap = result![1] as RouteComponentSwap;
+            expect(swap.route.length).toBe(2);
+            expect(swap.amountOut).toBeGreaterThan(0n);
+            expect(swap.currencyIn.equals(tokenA_900));
+            expect(swap.currencyOut.equals(tokenB_900));
+
+            const bridgeOut = result![2] as RouteComponentBridge;
+            expect(bridgeOut.currencyIn.equals(tokenB_900));
+            expect(bridgeOut.currencyOut.equals(tokenB_902));
+        });
+    });
+});

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.test.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.test.ts
@@ -14,7 +14,7 @@ import {
     RouteComponentSwap,
 } from "./getUniswapV4RouteMultichain.js";
 
-describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
+describe("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
     const config = createConfig({
         chains: [opChainL1],
         transports: {
@@ -45,7 +45,6 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
     describe("getUniswapV4RouteMultichain", () => {
         test("same chain, with liquidity", async () => {
             // Tokens are on the same chain (900)
-            // Liquidity is on different chain (900)
             const result = await getUniswapV4RouteMultichain(queryClient, config, {
                 currencyIn: tokenA_900,
                 currencyOut: tokenB_900,
@@ -58,6 +57,34 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             expect(result!.amountOut).toBeGreaterThan(0n);
             expect(result!.currencyIn.equals(tokenA_900));
             expect(result!.currencyOut.equals(tokenB_900));
+        });
+
+        test("same chain, with liquidity, amount higher than eth intermeidate swap", async () => {
+            // Tokens are on the same chain (900)
+            const result = await getUniswapV4RouteMultichain(queryClient, config, {
+                currencyIn: tokenA_900,
+                currencyOut: tokenB_900,
+                exactAmount: parseUnits("50", tokenA_900.decimals),
+                contractsByChain,
+                currencyHopsByChain,
+            });
+            expect(result).not.toBe(null);
+            expect(result!.route.length).toBe(1);
+            expect(result!.amountOut).toBeGreaterThan(0n);
+            expect(result!.currencyIn.equals(tokenA_900));
+            expect(result!.currencyOut.equals(tokenB_900));
+        });
+
+        test("same chain, with liquidity, amount too high", async () => {
+            // Tokens are on the same chain (900)
+            const result = await getUniswapV4RouteMultichain(queryClient, config, {
+                currencyIn: tokenA_900,
+                currencyOut: tokenB_900,
+                exactAmount: parseUnits("10000", tokenA_900.decimals),
+                contractsByChain,
+                currencyHopsByChain,
+            });
+            expect(result).toBe(null);
         });
 
         test("same chain, no liquidity", async () => {

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.test.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.test.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 import { createConfig, http } from "@wagmi/core";
-import { parseEther, zeroAddress } from "viem";
+import { parseUnits, zeroAddress } from "viem";
 import { describe, expect, test } from "vitest";
 
 import { opChainA, opChainB, opChainL1 } from "../chains/supersim.js";
@@ -49,7 +49,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             const result = await getUniswapV4RouteMultichain(queryClient, config, {
                 currencyIn: tokenA_900,
                 currencyOut: tokenB_900,
-                exactAmount: parseEther("1"),
+                exactAmount: parseUnits("1", tokenA_900.decimals),
                 contractsByChain,
                 currencyHopsByChain,
             });
@@ -66,7 +66,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             const result = await getUniswapV4RouteMultichain(queryClient, config, {
                 currencyIn: tokenA_901,
                 currencyOut: tokenB_901,
-                exactAmount: parseEther("1"),
+                exactAmount: parseUnits("1", tokenA_901.decimals),
                 contractsByChain,
                 currencyHopsByChain,
             });
@@ -83,7 +83,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             const result = await getUniswapV4RouteMultichain(queryClient, config, {
                 currencyIn: tokenA_901,
                 currencyOut: tokenB_902,
-                exactAmount: parseEther("1"),
+                exactAmount: parseUnits("1", tokenA_901.decimals),
                 contractsByChain,
                 currencyHopsByChain,
             });
@@ -102,7 +102,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             const result = await getRouteMultichain(queryClient, config, {
                 currencyIn: tokenA_900,
                 currencyOut: tokenA_901,
-                exactAmount: parseEther("1"),
+                exactAmount: parseUnits("1", tokenA_900.decimals),
                 contractsByChain,
                 currencyHopsByChain,
             });
@@ -120,7 +120,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             const result = await getRouteMultichain(queryClient, config, {
                 currencyIn: tokenA_900,
                 currencyOut: tokenB_900,
-                exactAmount: parseEther("1"),
+                exactAmount: parseUnits("1", tokenA_900.decimals),
                 contractsByChain,
                 currencyHopsByChain,
             });
@@ -140,7 +140,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             const result = await getRouteMultichain(queryClient, config, {
                 currencyIn: tokenA_900,
                 currencyOut: tokenB_901,
-                exactAmount: parseEther("1"),
+                exactAmount: parseUnits("1", tokenA_900.decimals),
                 contractsByChain,
                 currencyHopsByChain,
             });
@@ -164,7 +164,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             const result = await getRouteMultichain(queryClient, config, {
                 currencyIn: tokenA_901,
                 currencyOut: tokenB_900,
-                exactAmount: parseEther("1"),
+                exactAmount: parseUnits("1", tokenA_901.decimals),
                 contractsByChain,
                 currencyHopsByChain,
             });
@@ -188,7 +188,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             const result = await getRouteMultichain(queryClient, config, {
                 currencyIn: tokenA_901,
                 currencyOut: tokenB_902,
-                exactAmount: parseEther("1"),
+                exactAmount: parseUnits("1", tokenA_901.decimals),
                 contractsByChain,
                 currencyHopsByChain,
             });

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.test.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.test.ts
@@ -54,7 +54,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
                 currencyHopsByChain,
             });
             expect(result).not.toBe(null);
-            expect(result!.route.length).toBe(2);
+            expect(result!.route.length).toBe(1);
             expect(result!.amountOut).toBeGreaterThan(0n);
             expect(result!.currencyIn.equals(tokenA_900));
             expect(result!.currencyOut.equals(tokenB_900));
@@ -71,7 +71,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
                 currencyHopsByChain,
             });
             expect(result).not.toBe(null);
-            expect(result!.route.length).toBe(2);
+            expect(result!.route.length).toBe(1);
             expect(result!.amountOut).toBeGreaterThan(0n);
             expect(result!.currencyIn.equals(tokenA_900));
             expect(result!.currencyOut.equals(tokenB_900));
@@ -88,7 +88,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
                 currencyHopsByChain,
             });
             expect(result).not.toBe(null);
-            expect(result!.route.length).toBe(2);
+            expect(result!.route.length).toBe(1);
             expect(result!.amountOut).toBeGreaterThan(0n);
             expect(result!.currencyIn.equals(tokenA_900));
             expect(result!.currencyOut.equals(tokenB_900));
@@ -132,7 +132,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             expect(flows.length).toBe(1);
 
             const swap = flows[0] as RouteComponentSwap;
-            expect(swap.route.length).toBe(2);
+            expect(swap.route.length).toBe(1);
             expect(swap.amountOut).toBeGreaterThan(0n);
             expect(swap.currencyIn.equals(tokenA_900));
             expect(swap.currencyOut.equals(tokenB_900));
@@ -154,7 +154,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             expect(flows.length).toBe(2);
 
             const swap = flows[0] as RouteComponentSwap;
-            expect(swap.route.length).toBe(2);
+            expect(swap.route.length).toBe(1);
             expect(swap.amountOut).toBeGreaterThan(0n);
             expect(swap.currencyIn.equals(tokenA_900));
             expect(swap.currencyOut.equals(tokenB_900));
@@ -184,7 +184,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             expect(bridge.currencyOut.equals(tokenA_900));
 
             const swap = flows[1] as RouteComponentSwap;
-            expect(swap.route.length).toBe(2);
+            expect(swap.route.length).toBe(1);
             expect(swap.amountOut).toBeGreaterThan(0n);
             expect(swap.currencyIn.equals(tokenA_900));
             expect(swap.currencyOut.equals(tokenB_900));
@@ -210,7 +210,7 @@ describe.skip("uniswap/getUniswapV4RouteMultichain.test.ts", function () {
             expect(bridgeIn.currencyOut.equals(tokenA_900));
 
             const swap = flows[1] as RouteComponentSwap;
-            expect(swap.route.length).toBe(2);
+            expect(swap.route.length).toBe(1);
             expect(swap.amountOut).toBeGreaterThan(0n);
             expect(swap.currencyIn.equals(tokenA_900));
             expect(swap.currencyOut.equals(tokenB_900));

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.ts
@@ -6,7 +6,7 @@ import { Address, zeroAddress } from "viem";
 
 import { Currency, getSharedChainTokenPairs, getUniswapV4Address } from "../currency/currency.js";
 import { MultichainToken } from "../currency/multichainToken.js";
-import { PoolKey, PoolKeyOptions } from "../types/PoolKey.js";
+import { PathKey, PoolKey, PoolKeyOptions, poolKeysToPath } from "../types/PoolKey.js";
 
 import { getUniswapV4Route, getUniswapV4RoutesWithLiquidity } from "./getUniswapV4Route.js";
 
@@ -139,6 +139,7 @@ export interface RouteComponentSwap {
     currencyIn: Currency;
     currencyOut: Currency;
     route: PoolKey[];
+    path: PathKey[];
     amountOut: bigint;
     gasEstimate: bigint;
 }
@@ -196,12 +197,15 @@ export async function getRouteMultichain(
     // Mixed Bridge/Swap/Bridge
     const flows: RouteComponent[] = [];
 
+    const path = poolKeysToPath(getUniswapV4Address(route.currencyIn), route.route);
+
     const swap: RouteComponentSwap = {
         type: "SWAP",
         chainId: route.currencyIn.chainId,
         currencyIn: route.currencyIn,
         currencyOut: route.currencyOut,
         route: route.route,
+        path,
         amountOut: route.amountOut,
         gasEstimate: route.gasEstimate,
     };

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.ts
@@ -2,7 +2,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { Config } from "@wagmi/core";
 import { maxBy, zip } from "lodash-es";
 import invariant from "tiny-invariant";
-import { Address } from "viem";
+import { Address, zeroAddress } from "viem";
 
 import { Currency, getSharedChainTokenPairs, getUniswapV4Address } from "../currency/currency.js";
 import { MultichainToken } from "../currency/multichainToken.js";
@@ -13,9 +13,9 @@ import { getUniswapV4Route, getUniswapV4RoutesWithLiquidity } from "./getUniswap
 export interface GetUniswapV4RouteMultichainParams {
     currencyIn: Currency;
     currencyOut: Currency;
-    currencyHopsByChain: Record<number, Address[]>;
+    currencyHopsByChain: Record<number, Address[] | undefined>;
     exactAmount: bigint;
-    contractsByChain: Record<number, { v4StateView: Address; v4Quoter: Address }>;
+    contractsByChain: Record<number, { v4StateView: Address; v4Quoter: Address } | undefined>;
     poolKeyOptions?: PoolKeyOptions[];
 }
 
@@ -47,7 +47,7 @@ export async function getUniswapV4RouteMultichain(
             tokenPairs.map(async (pair) => {
                 const [currIn, currOut] = pair;
                 const chainId = currIn.chainId;
-                const currencyHops = currencyHopsByChain[chainId] ?? [];
+                const currencyHops = currencyHopsByChain[chainId] ?? [zeroAddress];
                 const contracts = contractsByChain[chainId];
                 if (!contracts) return null; // No uniswap deployment on this chain
 
@@ -105,7 +105,7 @@ export async function getUniswapV4RoutesWithLiquidityMultichain(
         tokenPairs.map(async (pair) => {
             const [currIn, currOut] = pair;
             const chainId = currIn.chainId;
-            const currencyHops = currencyHopsByChain[chainId] ?? [];
+            const currencyHops = currencyHopsByChain[chainId] ?? [zeroAddress]; // Default to just checking native token
             const contracts = contractsByChain[chainId];
             invariant(
                 !!contracts,

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.ts
@@ -176,15 +176,9 @@ export async function getRouteMultichain(
     }
 
     if (currencyIn instanceof MultichainToken) {
-        // BRIDGE: `currencyIn.getRemoteToken(currencyOut.chainId).equals(currencyOut)`
+        // BRIDGE
         if (currencyIn.getRemoteToken(currencyOut.chainId)?.equals(currencyOut)) {
-            return [
-                {
-                    type: "BRIDGE",
-                    currencyIn: currencyIn,
-                    currencyOut: currencyOut,
-                },
-            ];
+            return [{ type: "BRIDGE", currencyIn, currencyOut }];
         }
     }
 

--- a/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.ts
+++ b/packages/veraswap-sdk/src/uniswap/getUniswapV4RouteMultichain.ts
@@ -1,0 +1,229 @@
+import { QueryClient } from "@tanstack/react-query";
+import { Config } from "@wagmi/core";
+import { maxBy, zip } from "lodash-es";
+import invariant from "tiny-invariant";
+import { Address } from "viem";
+
+import { Currency, getSharedChainTokenPairs, getUniswapV4Address } from "../currency/currency.js";
+import { MultichainToken } from "../currency/multichainToken.js";
+import { PoolKey, PoolKeyOptions } from "../types/PoolKey.js";
+
+import { getUniswapV4Route, getUniswapV4RoutesWithLiquidity } from "./getUniswapV4Route.js";
+
+export interface GetUniswapV4RouteMultichainParams {
+    currencyIn: Currency;
+    currencyOut: Currency;
+    currencyHopsByChain: Record<number, Address[]>;
+    exactAmount: bigint;
+    contractsByChain: Record<number, { v4StateView: Address; v4Quoter: Address }>;
+    poolKeyOptions?: PoolKeyOptions[];
+}
+
+/**
+ * Get best Uniswap V4 Route for chains where token share a deployment
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ * @returns List with token pair & supported routes for that pair
+ */
+export async function getUniswapV4RouteMultichain(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetUniswapV4RouteMultichainParams,
+): Promise<{
+    currencyIn: Currency;
+    currencyOut: Currency;
+    route: PoolKey[];
+    amountOut: bigint;
+    gasEstimate: bigint;
+} | null> {
+    const { currencyIn, currencyOut, currencyHopsByChain, exactAmount, contractsByChain, poolKeyOptions } = params;
+    invariant(currencyIn.equals(currencyOut) === false, "Cannot swap same token");
+
+    const tokenPairs = getSharedChainTokenPairs(currencyIn, currencyOut);
+
+    const routes = (
+        await Promise.all(
+            tokenPairs.map(async (pair) => {
+                const [currIn, currOut] = pair;
+                const chainId = currIn.chainId;
+                const currencyHops = currencyHopsByChain[chainId] ?? [];
+                const contracts = contractsByChain[chainId];
+                if (!contracts) return null; // No uniswap deployment on this chain
+
+                const route = await getUniswapV4Route(queryClient, wagmiConfig, {
+                    chainId,
+                    currencyIn: getUniswapV4Address(currIn),
+                    currencyOut: getUniswapV4Address(currOut),
+                    currencyHops,
+                    exactAmount,
+                    contracts,
+                    poolKeyOptions,
+                });
+                if (!route) return null;
+
+                return {
+                    ...route,
+                    currencyIn: currIn,
+                    currencyOut: currOut,
+                };
+            }),
+        )
+    ).filter((route) => !!route);
+
+    if (routes.length === 0) return null; // No active liquidity
+
+    const bestRoute = maxBy(routes, (r) => r.amountOut)!;
+    return bestRoute;
+}
+
+export interface GetUniswapV4RoutesWithLiquidityMultichainParams {
+    currencyIn: Currency;
+    currencyOut: Currency;
+    currencyHopsByChain: Record<number, Address[]>;
+    contractsByChain: Record<number, { v4StateView: Address }>;
+    poolKeyOptions?: PoolKeyOptions[];
+}
+/**
+ * Take token pair and find which chain(s) they can be swapped on
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ * @returns List with token pair & supported routes for that pair
+ */
+export async function getUniswapV4RoutesWithLiquidityMultichain(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetUniswapV4RoutesWithLiquidityMultichainParams,
+) {
+    const { currencyIn, currencyOut, currencyHopsByChain, contractsByChain, poolKeyOptions } = params;
+    invariant(currencyIn.equals(currencyOut) === false, "Cannot swap same token");
+
+    const tokenPairs = getSharedChainTokenPairs(currencyIn, currencyOut);
+
+    const routesWithLiquidity = await Promise.all(
+        tokenPairs.map(async (pair) => {
+            const [currIn, currOut] = pair;
+            const chainId = currIn.chainId;
+            const currencyHops = currencyHopsByChain[chainId] ?? [];
+            const contracts = contractsByChain[chainId];
+            invariant(
+                !!contracts,
+                `getUniswapV4RoutesWithLiquidityMultichain: contracts undefined for chain ${chainId}`,
+            );
+
+            return getUniswapV4RoutesWithLiquidity(queryClient, wagmiConfig, {
+                chainId,
+                currencyIn: getUniswapV4Address(currIn),
+                currencyOut: getUniswapV4Address(currOut),
+                currencyHops,
+                contracts,
+                poolKeyOptions,
+            });
+        }),
+    );
+
+    const multichainRoutes = zip(tokenPairs, routesWithLiquidity).map(([pair, routes]) => {
+        return {
+            pair: pair!,
+            routes: routes!,
+        };
+    });
+
+    return multichainRoutes;
+}
+
+export interface RouteComponentSwap {
+    type: "SWAP";
+    chainId: number;
+    currencyIn: Currency;
+    currencyOut: Currency;
+    route: PoolKey[];
+    amountOut: bigint;
+    gasEstimate: bigint;
+}
+
+export interface RouteComponentBridge {
+    type: "BRIDGE";
+    currencyIn: Currency;
+    currencyOut: Currency;
+}
+
+export type RouteComponent = RouteComponentSwap | RouteComponentBridge;
+
+/**
+ * Get list of asset flows to get from currencyIn to currencyOut
+ * @param queryClient
+ * @param wagmiConfig
+ * @param params
+ * @returns list of asset flows which either represent:
+ *  - assets on same chain to be swapped
+ *  - assets on different chains that are remote tokens of each other
+ */
+export async function getRouteMultichain(
+    queryClient: QueryClient,
+    wagmiConfig: Config,
+    params: GetUniswapV4RouteMultichainParams,
+): Promise<[RouteComponent, ...RouteComponent[]] | null> {
+    const { currencyIn, currencyOut } = params;
+
+    invariant(currencyIn.equals(currencyOut) === false, "Cannot swap or bridge same token");
+
+    // BRIDGE ONLY
+    // BRIDGE: Native token bridge
+    if (currencyIn.isNative && currencyOut.isNative) {
+        return [{ type: "BRIDGE", currencyIn, currencyOut }];
+    }
+
+    if (currencyIn instanceof MultichainToken) {
+        // BRIDGE: `currencyIn.getRemoteToken(currencyOut.chainId).equals(currencyOut)`
+        if (currencyIn.getRemoteToken(currencyOut.chainId)?.equals(currencyOut)) {
+            return [
+                {
+                    type: "BRIDGE",
+                    currencyIn: currencyIn,
+                    currencyOut: currencyOut,
+                },
+            ];
+        }
+    }
+
+    // SWAP with pre-swap, post-swap bridging
+    // Find crosschain pools
+    const route = await getUniswapV4RouteMultichain(queryClient, wagmiConfig, params);
+    if (!route) return null;
+
+    // Mixed Bridge/Swap/Bridge
+    const flows: RouteComponent[] = [];
+
+    const swap: RouteComponentSwap = {
+        type: "SWAP",
+        chainId: route.currencyIn.chainId,
+        currencyIn: route.currencyIn,
+        currencyOut: route.currencyOut,
+        route: route.route,
+        amountOut: route.amountOut,
+        gasEstimate: route.gasEstimate,
+    };
+
+    if (!swap.currencyIn.equals(currencyIn)) {
+        // Add input bridge flow
+        flows.push({
+            type: "BRIDGE",
+            currencyIn,
+            currencyOut: swap.currencyIn,
+        });
+    }
+    // Add swap
+    flows.push(swap);
+    if (!swap.currencyOut.equals(currencyOut)) {
+        // Add ouput bridge flow
+        flows.push({
+            type: "BRIDGE",
+            currencyIn: swap.currencyOut,
+            currencyOut,
+        });
+    }
+
+    return flows as [RouteComponent, ...RouteComponent[]];
+}

--- a/packages/veraswap-sdk/src/uniswap/index.ts
+++ b/packages/veraswap-sdk/src/uniswap/index.ts
@@ -1,4 +1,7 @@
 export * from "./constants/index.js";
 export * from "./routing/index.js";
+
+export * from "./getUniswapV4Route.js";
+export * from "./getUniswapV4RouteMultichain.js";
 export * from "./routerCommands.js";
 export * from "./v4Planner.js";

--- a/packages/veraswap-sdk/src/uniswap/v4Planner.ts
+++ b/packages/veraswap-sdk/src/uniswap/v4Planner.ts
@@ -56,7 +56,7 @@ export const POOL_KEY_STRUCT = [
 ] as const;
 
 // const PATH_KEY_STRUCT = '(address intermediateCurrency,uint256 fee,int24 tickSpacing,address hooks,bytes hookData)'
-export const PATH_KEY_STRUCt = [
+export const PATH_KEY_STRUCT = [
     { name: "intermediateCurrency", type: "address" },
     { name: "fee", type: "uint256" },
     { name: "tickSpacing", type: "int24" },
@@ -78,7 +78,7 @@ export const SWAP_EXACT_IN_SINGLE_STRUCT = [
 //   '(address currencyIn,' + PATH_KEY_STRUCT + '[] path,uint128 amountIn,uint128 amountOutMinimum)'
 export const SWAP_EXACT_IN_STRUCT = [
     { name: "currencyIn", type: "address" },
-    { name: "path", type: "tuple[]", internalType: "struct PathKey[]", components: PATH_KEY_STRUCt },
+    { name: "path", type: "tuple[]", internalType: "struct PathKey[]", components: PATH_KEY_STRUCT },
     { name: "amountIn", type: "uint128" },
     { name: "amountOutMinimum", type: "uint128" },
 ] as const;
@@ -97,7 +97,7 @@ export const SWAP_EXACT_OUT_SINGLE_STRUCT = [
 //   '(address currencyOut,' + PATH_KEY_STRUCT + '[] path,uint128 amountOut,uint128 amountInMaximum)'
 export const SWAP_EXACT_OUT_STRUCT = [
     { name: "currencyOut", type: "address" },
-    { name: "path", type: "tuple[]", internalType: "struct PathKey[]", components: PATH_KEY_STRUCt },
+    { name: "path", type: "tuple[]", internalType: "struct PathKey[]", components: PATH_KEY_STRUCT },
     { name: "amountOut", type: "uint128" },
     { name: "amountInMaximum", type: "uint128" },
 ] as const;

--- a/packages/veraswap-sdk/src/utils/getAssetFlows.ts
+++ b/packages/veraswap-sdk/src/utils/getAssetFlows.ts
@@ -5,6 +5,7 @@ import { Currency } from "../currency/currency.js";
 import { Ether } from "../currency/ether.js";
 import { MultichainToken } from "../currency/multichainToken.js";
 import { PoolKey } from "../types/PoolKey.js";
+import { RouteComponent, RouteComponentBridge, RouteComponentSwap } from "../uniswap/getUniswapV4RouteMultichain.js";
 
 /**
  * Take token pair and return list of token pairs on same chain using their remote tokens
@@ -221,44 +222,46 @@ export function getAssetFlows(
 
 export interface TransactionTypeSwapBridge {
     type: "SWAP_BRIDGE";
-    swap: AssetFlowSwap;
-    bridge: AssetFlowBridge;
+    swap: RouteComponentSwap;
+    bridge: RouteComponentBridge;
 }
 
 export interface TransactionTypeBridgeSwap {
     type: "BRIDGE_SWAP";
-    bridge: AssetFlowBridge;
-    swap: AssetFlowSwap;
+    bridge: RouteComponentBridge;
+    swap: RouteComponentSwap;
 }
 
-export type TransactionType = AssetFlowSwap | AssetFlowBridge | TransactionTypeSwapBridge | TransactionTypeBridgeSwap;
+export type TransactionType = RouteComponent | TransactionTypeSwapBridge | TransactionTypeBridgeSwap;
 /**
  * Convert list of asset flows to TransactionType (used on frontend)
  * @param flows
  */
-export function assetFlowsToTransactionType(flows: [AssetFlow, ...AssetFlow[]]): TransactionType | null {
-    invariant(flows.length >= 1, "flows.length MUST be >= 1");
-    if (flows.length === 1) {
-        return flows[0];
+export function assetFlowsToTransactionType(
+    routeComponents: [RouteComponent, ...RouteComponent[]],
+): TransactionType | null {
+    invariant(routeComponents.length >= 1, "routeComponents.length MUST be >= 1");
+    if (routeComponents.length === 1) {
+        return routeComponents[0];
     }
 
-    if (flows.length === 2) {
-        if (flows[0].type === "SWAP" && flows[1].type === "BRIDGE") {
+    if (routeComponents.length === 2) {
+        if (routeComponents[0].type === "SWAP" && routeComponents[1].type === "BRIDGE") {
             return {
                 type: "SWAP_BRIDGE",
-                swap: flows[0],
-                bridge: flows[1],
+                swap: routeComponents[0],
+                bridge: routeComponents[1],
             };
-        } else if (flows[0].type === "BRIDGE" && flows[1].type === "SWAP") {
+        } else if (routeComponents[0].type === "BRIDGE" && routeComponents[1].type === "SWAP") {
             return {
                 type: "BRIDGE_SWAP",
-                bridge: flows[0],
-                swap: flows[1],
+                bridge: routeComponents[0],
+                swap: routeComponents[1],
             };
         }
-        throw new Error("flows.length === 2 but not SWAP_BRIDGE / BRIDGE_SWAP");
+        throw new Error("routeComponents.length === 2 but not SWAP_BRIDGE / BRIDGE_SWAP");
     }
 
-    //Longer flows unsupported
+    //Longer routes unsupported
     return null;
 }

--- a/packages/veraswap-sdk/src/utils/getAssetFlows.ts
+++ b/packages/veraswap-sdk/src/utils/getAssetFlows.ts
@@ -150,8 +150,6 @@ export interface AssetFlowBridge {
 
 export type AssetFlow = AssetFlowSwap | AssetFlowBridge;
 
-// TODO: Update quoting logic to use actual API and use an amount/minLiquidity parameter (current logic just checks hard-coded poolKeys)
-
 /**
  * Get list of asset flows to get from currencyIn to currencyOut
  * @param currencyIn
@@ -186,7 +184,6 @@ export function getAssetFlows(
     if (poolKeyOptions.length == 0) return null;
 
     // Mixed Bridge/Swap/Bridge
-    // TODO: Find optimal pool key using quoting & gas estimations
     const pool = poolKeyOptions[0];
     const flows: AssetFlow[] = [];
     const swap: AssetFlowSwap = {

--- a/packages/veraswap-sdk/src/utils/getAssetFlows.ts
+++ b/packages/veraswap-sdk/src/utils/getAssetFlows.ts
@@ -173,15 +173,9 @@ export function getAssetFlows(
     }
 
     if (currencyIn instanceof MultichainToken) {
-        // BRIDGE: `currencyIn.getRemoteToken(currencyOut.chainId).equals(currencyOut)`
+        // BRIDGE
         if (currencyIn.getRemoteToken(currencyOut.chainId)?.equals(currencyOut)) {
-            return [
-                {
-                    type: "BRIDGE",
-                    currencyIn: currencyIn,
-                    currencyOut: currencyOut,
-                },
-            ];
+            return [{ type: "BRIDGE", currencyIn: currencyIn, currencyOut: currencyOut }];
         }
     }
 
@@ -214,7 +208,7 @@ export function getAssetFlows(
     // Add swap
     flows.push(swap);
     if (!swap.currencyOut.equals(currencyOut)) {
-        // Add ouput bridge flow
+        // Add output bridge flow
         flows.push({
             type: "BRIDGE",
             currencyIn: swap.currencyOut,

--- a/packages/veraswap-sdk/src/utils/getTransactionType.test.ts
+++ b/packages/veraswap-sdk/src/utils/getTransactionType.test.ts
@@ -1,57 +1,58 @@
-import { describe, expect, test } from "vitest";
-
-import { LOCAL_CURRENCIES, LOCAL_POOLS } from "../constants/tokens.js";
-
-import { getTransactionType } from "./getTransactionType.js";
-
-describe("utils/getTransactionType.test.ts", function () {
-    const tokenA_900 = LOCAL_CURRENCIES[0];
-    const tokenA_901 = LOCAL_CURRENCIES[1];
-    const tokenB_900 = LOCAL_CURRENCIES[3];
-    const tokenB_901 = LOCAL_CURRENCIES[4];
-
-    test("BRIDGE", () => {
-        const transaction = getTransactionType({
-            poolKeys: LOCAL_POOLS,
-            currencyIn: tokenA_900,
-            currencyOut: tokenA_901,
-        });
-        expect(transaction?.type).toBe("BRIDGE");
-    });
-
-    test("SWAP", () => {
-        const transaction = getTransactionType({
-            poolKeys: LOCAL_POOLS,
-            currencyIn: tokenA_900,
-            currencyOut: tokenB_900,
-        });
-        expect(transaction?.type).toBe("SWAP");
-    });
-
-    test("SWAP_BRIDGE", () => {
-        const transaction = getTransactionType({
-            poolKeys: LOCAL_POOLS,
-            currencyIn: tokenA_900,
-            currencyOut: tokenB_901,
-        });
-        expect(transaction?.type).toBe("SWAP_BRIDGE");
-    });
-
-    test("BRIDGE_SWAP", () => {
-        const transaction = getTransactionType({
-            poolKeys: LOCAL_POOLS,
-            currencyIn: tokenA_901,
-            currencyOut: tokenB_900,
-        });
-        expect(transaction?.type).toBe("BRIDGE_SWAP");
-    });
-
-    test("null", () => {
-        const transaction = getTransactionType({
-            poolKeys: LOCAL_POOLS,
-            currencyIn: tokenA_901,
-            currencyOut: tokenB_901,
-        });
-        expect(transaction).toBe(null);
-    });
-});
+// TODO: enable again. but this depends on the using our new quoter, which we already test
+// import { describe, expect, test } from "vitest";
+//
+// import { LOCAL_CURRENCIES, LOCAL_POOLS } from "../constants/tokens.js";
+//
+// import { getTransactionType } from "./getTransactionType.js";
+//
+// describe("utils/getTransactionType.test.ts", function () {
+//     const tokenA_900 = LOCAL_CURRENCIES[0];
+//     const tokenA_901 = LOCAL_CURRENCIES[1];
+//     const tokenB_900 = LOCAL_CURRENCIES[3];
+//     const tokenB_901 = LOCAL_CURRENCIES[4];
+//
+//     test("BRIDGE", () => {
+//         const transaction = getTransactionType({
+//             poolKeys: LOCAL_POOLS,
+//             currencyIn: tokenA_900,
+//             currencyOut: tokenA_901,
+//         });
+//         expect(transaction?.type).toBe("BRIDGE");
+//     });
+//
+//     test("SWAP", () => {
+//         const transaction = getTransactionType({
+//             poolKeys: LOCAL_POOLS,
+//             currencyIn: tokenA_900,
+//             currencyOut: tokenB_900,
+//         });
+//         expect(transaction?.type).toBe("SWAP");
+//     });
+//
+//     test("SWAP_BRIDGE", () => {
+//         const transaction = getTransactionType({
+//             poolKeys: LOCAL_POOLS,
+//             currencyIn: tokenA_900,
+//             currencyOut: tokenB_901,
+//         });
+//         expect(transaction?.type).toBe("SWAP_BRIDGE");
+//     });
+//
+//     test("BRIDGE_SWAP", () => {
+//         const transaction = getTransactionType({
+//             poolKeys: LOCAL_POOLS,
+//             currencyIn: tokenA_901,
+//             currencyOut: tokenB_900,
+//         });
+//         expect(transaction?.type).toBe("BRIDGE_SWAP");
+//     });
+//
+//     test("null", () => {
+//         const transaction = getTransactionType({
+//             poolKeys: LOCAL_POOLS,
+//             currencyIn: tokenA_901,
+//             currencyOut: tokenB_901,
+//         });
+//         expect(transaction).toBe(null);
+//     });
+// });

--- a/packages/veraswap-sdk/src/utils/getTransactionType.test.ts
+++ b/packages/veraswap-sdk/src/utils/getTransactionType.test.ts
@@ -1,3 +1,6 @@
+import { describe } from "vitest";
+
+describe.skip("getTransactionType.test.ts");
 // TODO: enable again. but this depends on the using our new quoter, which we already test
 // import { describe, expect, test } from "vitest";
 //

--- a/packages/veraswap-sdk/src/utils/getTransactionType.ts
+++ b/packages/veraswap-sdk/src/utils/getTransactionType.ts
@@ -1,15 +1,15 @@
 import { Currency } from "../currency/currency.js";
 import { PoolKey } from "../types/PoolKey.js";
+import { RouteComponent } from "../uniswap/getUniswapV4RouteMultichain.js";
 
-import { assetFlowsToTransactionType, getAssetFlows } from "./getAssetFlows.js";
+import { assetFlowsToTransactionType } from "./getAssetFlows.js";
 
 export interface TransactionTypeSwap {
     type: "SWAP";
     chainId: number;
     currencyIn: Currency;
     currencyOut: Currency;
-    poolKey: PoolKey;
-    zeroForOne: boolean;
+    route: PoolKey[];
     // Not needed here but used for consistency
     withSuperchain?: boolean;
 }
@@ -49,14 +49,15 @@ export type TransactionType =
 export function getTransactionType({
     currencyIn,
     currencyOut,
-    poolKeys,
+    routeComponents,
 }: {
     currencyIn: Currency;
     currencyOut: Currency;
-    poolKeys: Record<number, PoolKey[]>;
+    routeComponents: [RouteComponent, ...RouteComponent[]] | null;
 }): TransactionType | null {
     if (currencyIn.equals(currencyOut)) return null;
-    const flows = getAssetFlows(currencyIn, currencyOut, poolKeys);
-    if (!flows) return null;
-    return assetFlowsToTransactionType(flows);
+
+    if (!routeComponents) return null;
+    // TODO: refactor this to take route components
+    return assetFlowsToTransactionType(routeComponents);
 }

--- a/packages/veraswap-sdk/src/utils/getTransactionType.ts
+++ b/packages/veraswap-sdk/src/utils/getTransactionType.ts
@@ -1,5 +1,5 @@
 import { Currency } from "../currency/currency.js";
-import { PoolKey } from "../types/PoolKey.js";
+import { PathKey, PoolKey } from "../types/PoolKey.js";
 import { RouteComponent } from "../uniswap/getUniswapV4RouteMultichain.js";
 
 import { assetFlowsToTransactionType } from "./getAssetFlows.js";
@@ -10,6 +10,7 @@ export interface TransactionTypeSwap {
     currencyIn: Currency;
     currencyOut: Currency;
     route: PoolKey[];
+    path: PathKey[];
     // Not needed here but used for consistency
     withSuperchain?: boolean;
 }
@@ -58,6 +59,6 @@ export function getTransactionType({
     if (currencyIn.equals(currencyOut)) return null;
 
     if (!routeComponents) return null;
-    // TODO: refactor this to take route components
+
     return assetFlowsToTransactionType(routeComponents);
 }


### PR DESCRIPTION
Add support for Multihop quoting & swaps for Uniswap V4 pools. When swapping A / B we look at the following:
- Chains where tokens share a chain
- Pools with A/B or with any intermediate tokens (default to just native token, zero address, as an intermediate)
- For each chain, quote all possible single hop & 2-hop swaps, and select the best one.
This is by no means a perfect quoting system but is already vastly more superior to our current solution.

See DEV-1355 for deeper explanation of the algorithm.